### PR TITLE
[GMMQ-27] feat: RestDocs 추가 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ java {
 }
 
 configurations {
+	asciidoctorExt
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
@@ -47,4 +48,25 @@ tasks.named('test') {
 tasks.named('asciidoctor') {
 	inputs.dir snippetsDir
 	dependsOn test
+}
+
+tasks.register('copyDocument', Copy) {
+	dependsOn asciidoctor
+	doFirst {
+		delete file('src/main/resources/static/docs')
+	}
+	from file("build/docs/asciidoc")
+	into file("src/main/resources/static/docs")
+}
+
+asciidoctor {
+	dependsOn test
+	inputs.dir snippetsDir
+	configurations 'asciidoctorExt'
+
+	baseDirFollowsSourceFile()
+}
+
+build {
+	dependsOn copyDocument
 }

--- a/src/docs/asciidoc/docinfo.html
+++ b/src/docs/asciidoc/docinfo.html
@@ -1,0 +1,36 @@
+<script>
+    function ready(callbackFunc) {
+        if (document.readyState !== 'loading') {
+            // Document is already ready, call the callback directly
+            callbackFunc();
+        } else if (document.addEventListener) {
+            // All modern browsers to register DOMContentLoaded
+            document.addEventListener('DOMContentLoaded', callbackFunc);
+        } else {
+            // Old IE browsers
+            document.attachEvent('onreadystatechange', function () {
+                if (document.readyState === 'complete') {
+                    callbackFunc();
+                }
+            });
+        }
+    }
+
+    function openPopup(event) {
+
+        const target = event.target;
+        if (target.className !== "popup") { //(1)
+            return;
+        }
+
+        event.preventDefault();
+        const screenX = event.screenX;
+        const screenY = event.screenY;
+        window.open(target.href, target.text, `left=$, top=$, width=500, height=600, status=no, menubar=no, toolbar=no, resizable=no`);
+    }
+
+    ready(function () {
+        const el = document.getElementById("content");
+        el.addEventListener("click", event => openPopup(event), false);
+    });
+</script>

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,19 @@
+ifndef::snippets[]
+:snippets: ../../../build/generated-snippets
+endif::[]
+
+= Resumeme API Document
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectlinks:
+:docinfo: shared
+
+// 참고
+// 팝업으로 enum code 등을 띄우고 싶으면 src/docs/asciidoc/common 하위에
+// [filename].adoc 파일을 만들면 됩니다
+
+// filename은 src/test/java/o.d.r/common/DocumentLinkGenerator#DocUrl
+// 필드 중 htmlFileName과 동일한 이름을 주면 됩니다

--- a/src/main/java/org/devcourse/resumeme/common/domain/DocsEnumType.java
+++ b/src/main/java/org/devcourse/resumeme/common/domain/DocsEnumType.java
@@ -1,0 +1,9 @@
+package org.devcourse.resumeme.common.domain;
+
+public interface DocsEnumType {
+
+    String getType();
+
+    String getDescription();
+
+}

--- a/src/test/java/org/devcourse/resumeme/common/ControllerUnitTest.java
+++ b/src/test/java/org/devcourse/resumeme/common/ControllerUnitTest.java
@@ -1,0 +1,46 @@
+package org.devcourse.resumeme.common;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.devcourse.resumeme.common.controller.EnumController;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+
+@WebMvcTest({
+        EnumController.class
+})
+@AutoConfigureRestDocs
+@ExtendWith(RestDocumentationExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public abstract class ControllerUnitTest {
+
+    protected MockMvc mvc;
+
+    @Autowired
+    protected ObjectMapper mapper;
+
+    @BeforeEach
+    void setup(WebApplicationContext context, RestDocumentationContextProvider restDocumentation) {
+        mvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(documentationConfiguration(restDocumentation))
+                .build();
+    }
+
+    protected String toJson(Object data) throws JsonProcessingException {
+        return mapper.writeValueAsString(data);
+    }
+
+}

--- a/src/test/java/org/devcourse/resumeme/common/DocumentLinkGenerator.java
+++ b/src/test/java/org/devcourse/resumeme/common/DocumentLinkGenerator.java
@@ -1,0 +1,23 @@
+package org.devcourse.resumeme.common;
+
+public interface DocumentLinkGenerator {
+
+    static String generateLinkCode(DocUrl docUrl) {
+        return String.format("link:common/%s.html[%s %s,role=\"popup\"]", docUrl.htmlFileName, docUrl.codeName, "코드");
+    }
+
+    enum DocUrl {
+        ;
+
+        private final String htmlFileName;
+
+        private final String codeName;
+
+        DocUrl(String htmlFileName, String codeName) {
+            this.htmlFileName = htmlFileName;
+            this.codeName = codeName;
+        }
+
+    }
+
+}

--- a/src/test/java/org/devcourse/resumeme/common/EnumControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/common/EnumControllerTest.java
@@ -1,0 +1,84 @@
+package org.devcourse.resumeme.common;
+
+import org.devcourse.resumeme.common.controller.EnumController.EnumDocsResponse;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.operation.Operation;
+import org.springframework.restdocs.payload.AbstractFieldsSnippet;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.PayloadSubsectionExtractor;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.beneathPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.snippet.Attributes.attributes;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class EnumControllerTest extends ControllerUnitTest {
+
+    @Test
+    @Disabled
+    void 상태_코드값들을_api문서에_나타낸다() throws Exception {
+        //when
+        ResultActions result = mvc.perform(get("/enums")
+                .contentType(MediaType.APPLICATION_JSON));
+
+        //then
+        EnumDocsResponse response = parseResult(result.andReturn());
+
+        result.andExpect(status().isOk())
+                .andDo(
+                        document("enum-response",
+                                customResponseFields("test", enumConvertFieldDescriptor(null))
+                        )
+                );
+
+    }
+
+    private EnumDocsResponse parseResult(MvcResult result) throws IOException {
+        return mapper.readValue(result.getResponse().getContentAsByteArray(), EnumDocsResponse.class);
+    }
+
+    private CustomResponseFieldsSnippet customResponseFields(String enumName, FieldDescriptor... descriptors) {
+        return new CustomResponseFieldsSnippet("enum-response", beneathPath(enumName).withSubsectionId(enumName),
+                Arrays.asList(descriptors), attributes(key("enumTypeName").value(enumName)), true);
+    }
+
+    private FieldDescriptor[] enumConvertFieldDescriptor(Map<String, String> enumValues) {
+        return enumValues.entrySet().stream()
+                .map(x -> fieldWithPath(x.getKey()).description(x.getValue()))
+                .toArray(FieldDescriptor[]::new);
+    }
+
+    public static class CustomResponseFieldsSnippet extends AbstractFieldsSnippet {
+
+        public CustomResponseFieldsSnippet(String type, PayloadSubsectionExtractor<?> subsectionExtractor,
+                List<FieldDescriptor> descriptors, Map<String, Object> attributes,
+                boolean ignoreUndocumentedFields) {
+            super(type, descriptors, attributes, ignoreUndocumentedFields,
+                    subsectionExtractor);
+        }
+
+        @Override
+        protected MediaType getContentType(Operation operation) {
+            return operation.getResponse().getHeaders().getContentType();
+        }
+
+        @Override
+        protected byte[] getContent(Operation operation) {
+            return operation.getResponse().getContent();
+        }
+
+    }
+
+}

--- a/src/test/java/org/devcourse/resumeme/common/controller/EnumController.java
+++ b/src/test/java/org/devcourse/resumeme/common/controller/EnumController.java
@@ -1,0 +1,28 @@
+package org.devcourse.resumeme.common.controller;
+
+import org.devcourse.resumeme.common.domain.DocsEnumType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestController
+public class EnumController {
+
+    @GetMapping("/enums")
+    public EnumDocsResponse enums() {
+        return new EnumDocsResponse(to(null));
+    }
+
+    private Map<String, String> to(DocsEnumType[] enumTypes) {
+        return Arrays.stream(enumTypes)
+                .collect(Collectors.toMap(DocsEnumType::getType, DocsEnumType::getDescription));
+    }
+
+    public record EnumDocsResponse(Map<String, String> enumCode) {
+
+    }
+
+}

--- a/src/test/resources/org/springframework/restdocs/templates/enum-response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/enum-response-fields.snippet
@@ -1,0 +1,10 @@
+{{enumTypeName}}
+|===
+|코드|코드명
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+|===


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
enum, 테스트시 사용되는 공통 코드에 대한 설정 들입니다

## CC. 리뷰어
- docinfo.html : 특정 링크들을 팝업으로 띄우는 역할
- DocsEnumType : Enum class들 중 docs로 제공을 할 필요가 있으면 상속을 받아서 사용
- EnumController : 문서로 제공해야 할 enum들을 위한 테스트용 컨트롤러

### 추가 사용법
**enum class 문서화**
1. DocsEnumType 으로 명시
2. EnumController 반환 값에 추가 (EnumDocsResponse 필드에 `Map<String, String>`타입으로 하나더 추가 하면 됩니다)
    ```java
    public record EnumDocsResponse(Map<String, String> enumCode, // <- 기존 있던 값
              Map<String, String> userType) { // <- 계속 추가
    }
    ```
3. EnumControllerTest에서 추가
    ```java
    document("enum-response", 
        customResponseFields("userType",enumConvertFieldDescriptor(response.userType())),
        customResponseFields("enumCode",enumConvertFieldDescriptor(response.enumCode())), // <- 계속 추가
    )
    ```

**Link 생성**
1. DocumentLinkGenerator#DocUrl에 타입 추가
2. `DocumentLinkGenerator.generateLinkCode(DocUrl)` 반환 값 rest docs 작성 시 description에 추가
## 테스트 설명
- ControllerUnitTest : 컨트롤러 Mockmvc를 사용한 단위 테스트시 사용하면 됩니다 `@WebMvcTest` 에 필요한 클래스 타입 작성
- EnumControllerTest : 우선은 아무런 enum 값이 없어서 `@Disabled`처리 해뒀으니 나중에 필요 시 제거 해주세요

## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
