### PR TITLE
 feat: Event 도메인 분리

### DIFF
--- a/src/main/java/org/devcourse/resumeme/common/domain/BaseEntity.java
+++ b/src/main/java/org/devcourse/resumeme/common/domain/BaseEntity.java
@@ -18,6 +18,9 @@ public abstract class BaseEntity {
     @LastModifiedDate
     protected LocalDateTime lastModifiedDate;
 
+    protected BaseEntity() {
+    }
+
     protected BaseEntity(LocalDateTime createdDate, LocalDateTime lastModifiedDate) {
         this.createdDate = createdDate;
         this.lastModifiedDate = lastModifiedDate;

--- a/src/main/java/org/devcourse/resumeme/common/util/Validator.java
+++ b/src/main/java/org/devcourse/resumeme/common/util/Validator.java
@@ -1,0 +1,26 @@
+package org.devcourse.resumeme.common.util;
+
+import lombok.NoArgsConstructor;
+import org.devcourse.resumeme.global.advice.exception.CustomException;
+import org.springframework.util.StringUtils;
+
+import static lombok.AccessLevel.PRIVATE;
+
+@NoArgsConstructor(access = PRIVATE)
+public class Validator {
+
+    public static void validate(boolean predicate, String errorCode, String errorMessage) {
+        if (predicate) {
+            throw new CustomException(errorCode, errorMessage);
+        }
+    }
+
+    @NoArgsConstructor(access = PRIVATE)
+    public static class Condition {
+
+        public static boolean isBlank(String target) {
+            return !StringUtils.hasLength(target);
+        }
+
+    }
+}

--- a/src/main/java/org/devcourse/resumeme/domain/event/Event.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/Event.java
@@ -13,30 +13,28 @@ import java.util.List;
 
 import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.CascadeType.REMOVE;
+import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
 @NoArgsConstructor
-public class Event {
+public class Event extends BaseEntity {
 
     @Id
     @GeneratedValue
     private Long id;
 
-    private int maximumAttendee;
+    @Embedded
+    private EventInfo eventInfo;
 
-    private String title;
+    @Embedded
+    private EventTimeInfo eventTimeInfo;
 
-    private String content;
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "mentor_id")
+    private Mentor mentor;
 
-    private LocalDateTime openDateTime;
-
-    private LocalDateTime endDate;
-
-    private Position position;
-
-    private EventStatus status;
-
-    private Long mentorId;
+    @OneToMany(mappedBy = "event", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
+    private List<EventPosition> positions = new ArrayList<>();
 
     @OneToMany(mappedBy = "event", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
     private List<MenteeToEvent> attendedMentees = new ArrayList<>();

--- a/src/main/java/org/devcourse/resumeme/domain/event/Event.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/Event.java
@@ -22,6 +22,7 @@ import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.CascadeType.REMOVE;
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
+import static org.devcourse.resumeme.common.util.Validator.validate;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)
@@ -49,12 +50,21 @@ public class Event extends BaseEntity {
     private List<MenteeToEvent> attendedMentees = new ArrayList<>();
 
     public Event(EventInfo eventInfo, EventTimeInfo eventTimeInfo, Mentor mentor, List<Position> positions) {
+        validateInput(eventInfo, eventTimeInfo, mentor, positions);
+
         this.eventInfo = eventInfo;
         this.eventTimeInfo = eventTimeInfo;
         this.mentor = mentor;
         this.positions = positions.stream()
                 .map(position -> new EventPosition(position, this))
                 .toList();
+    }
+
+    private void validateInput(EventInfo eventInfo, EventTimeInfo eventTimeInfo, Mentor mentor, List<Position> positions) {
+        validate(eventInfo == null, "NO_EMPTY_VALUE", "빈 값일 수 없습니다");
+        validate(eventTimeInfo == null, "NO_EMPTY_VALUE", "빈 값일 수 없습니다");
+        validate(mentor == null, "NO_EMPTY_VALUE", "빈 값일 수 없습니다");
+        validate(positions == null, "NO_EMPTY_VALUE", "빈 값일 수 없습니다");
     }
 
     public int applicationToEvent(Long menteeId) {

--- a/src/main/java/org/devcourse/resumeme/domain/event/Event.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/Event.java
@@ -47,7 +47,7 @@ public class Event extends BaseEntity {
     private List<EventPosition> positions = new ArrayList<>();
 
     @OneToMany(mappedBy = "event", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
-    private List<MenteeToEvent> attendedMentees = new ArrayList<>();
+    private List<MenteeToEvent> applicants = new ArrayList<>();
 
     public Event(EventInfo eventInfo, EventTimeInfo eventTimeInfo, Mentor mentor, List<Position> positions) {
         validateInput(eventInfo, eventTimeInfo, mentor, positions);
@@ -67,16 +67,16 @@ public class Event extends BaseEntity {
         validate(positions == null, "NO_EMPTY_VALUE", "빈 값일 수 없습니다");
     }
 
-    public int applicationToEvent(Long menteeId) {
+    public int acceptMentee(Long menteeId) {
         checkDuplicateApplicationEvent(menteeId);
         eventInfo.checkAvailableApplication();
-        attendedMentees.add(new MenteeToEvent(this, menteeId));
+        applicants.add(new MenteeToEvent(this, menteeId));
 
-        return eventInfo.close(attendedMentees.size());
+        return eventInfo.close(applicants.size());
     }
 
     private void checkDuplicateApplicationEvent(Long menteeId) {
-        for (MenteeToEvent attendedMentee : attendedMentees) {
+        for (MenteeToEvent attendedMentee : applicants) {
             if (attendedMentee.isSameMentee(menteeId)) {
                 throw new EventException("DUPLICATE_APPLICATION_EVENT", "이미 신청한 이력이 있습니다");
             }
@@ -84,15 +84,15 @@ public class Event extends BaseEntity {
     }
 
     public int reject(Long menteeId) {
-        attendedMentees.removeIf(attendedMentee -> attendedMentee.isSameMentee(menteeId));
+        applicants.removeIf(attendedMentee -> attendedMentee.isSameMentee(menteeId));
 
-        return eventInfo.remainSeats(attendedMentees.size());
+        return eventInfo.remainSeats(applicants.size());
     }
 
     public int reOpenEvent() {
-        eventInfo.reOpen(attendedMentees.size());
+        eventInfo.reOpen(applicants.size());
 
-        return eventInfo.remainSeats(attendedMentees.size());
+        return eventInfo.remainSeats(applicants.size());
     }
 
     public void openReservationEvent(LocalDateTime nowDateTime) {

--- a/src/main/java/org/devcourse/resumeme/domain/event/Event.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/Event.java
@@ -1,11 +1,17 @@
 package org.devcourse.resumeme.domain.event;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import lombok.NoArgsConstructor;
-import org.devcourse.resumeme.common.domain.Position;
+import org.devcourse.resumeme.common.domain.BaseEntity;
+import org.devcourse.resumeme.domain.event.exception.EventException;
+import org.devcourse.resumeme.domain.metor.Mentor;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -40,14 +46,38 @@ public class Event extends BaseEntity {
     @OneToMany(mappedBy = "event", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
     private List<MenteeToEvent> attendedMentees = new ArrayList<>();
 
-    public Event(int maximumAttendee, String title, String content, LocalDateTime openDateTime, LocalDateTime endDate, Position position, Long mentorId) {
-        this.maximumAttendee = maximumAttendee;
-        this.title = title;
-        this.content = content;
-        this.openDateTime = openDateTime;
-        this.endDate = endDate;
-        this.position = position;
-        this.mentorId = mentorId;
+    public Event(EventInfo eventInfo, EventTimeInfo eventTimeInfo, Mentor mentor, List<EventPosition> positions) {
+        this.eventInfo = eventInfo;
+        this.eventTimeInfo = eventTimeInfo;
+        this.mentor = mentor;
+        this.positions = positions;
+    }
+
+    public void applicationToEvent(Long menteeId) {
+        checkDuplicateApplicationEvent(menteeId);
+        eventInfo.checkAvailableApplication();
+        attendedMentees.add(new MenteeToEvent(this, menteeId));
+        eventInfo.close(attendedMentees.size());
+    }
+
+    private void checkDuplicateApplicationEvent(Long menteeId) {
+        for (MenteeToEvent attendedMentee : attendedMentees) {
+            if (attendedMentee.isSameMentee(menteeId)) {
+                throw new EventException("DUPLICATE_APPLICATION_EVENT", "이미 신청한 이력이 있습니다");
+            }
+        }
+    }
+
+    public void reOpenEvent() {
+        eventInfo.reOpen(attendedMentees.size());
+    }
+
+    public void openReservationEvent() {
+        if (!eventTimeInfo.isAfterOpenTime(LocalDateTime.now())) {
+            throw new EventException("NOT_OPEN_TIME", "예약한 오픈 시간이 아닙니다");
+        }
+
+        eventInfo.open();
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/domain/event/Event.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/Event.java
@@ -83,12 +83,20 @@ public class Event extends BaseEntity {
         }
     }
 
-    public void reOpenEvent() {
-        eventInfo.reOpen(attendedMentees.size());
+    public int reject(Long menteeId) {
+        attendedMentees.removeIf(attendedMentee -> attendedMentee.isSameMentee(menteeId));
+
+        return eventInfo.remainSeats(attendedMentees.size());
     }
 
-    public void openReservationEvent() {
-        if (!eventTimeInfo.isAfterOpenTime(LocalDateTime.now())) {
+    public int reOpenEvent() {
+        eventInfo.reOpen(attendedMentees.size());
+
+        return eventInfo.remainSeats(attendedMentees.size());
+    }
+
+    public void openReservationEvent(LocalDateTime nowDateTime) {
+        if (!eventTimeInfo.isAfterOpenTime(nowDateTime)) {
             throw new EventException("NOT_OPEN_TIME", "예약한 오픈 시간이 아닙니다");
         }
 

--- a/src/main/java/org/devcourse/resumeme/domain/event/Event.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/Event.java
@@ -21,6 +21,7 @@ public class Event extends BaseEntity {
 
     @Id
     @GeneratedValue
+    @Column(name = "event_id")
     private Long id;
 
     @Embedded

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventInfo.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventInfo.java
@@ -1,0 +1,38 @@
+package org.devcourse.resumeme.domain.event;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Enumerated;
+import lombok.NoArgsConstructor;
+import org.devcourse.resumeme.domain.event.exception.EventException;
+
+import static jakarta.persistence.EnumType.STRING;
+
+@Embeddable
+@NoArgsConstructor
+public class EventInfo {
+
+    private int maximumAttendee;
+
+    private String title;
+
+    private String content;
+
+    @Enumerated(STRING)
+    private EventStatus status;
+
+    private EventInfo(int maximumAttendee, String title, String content, EventStatus status) {
+        this.maximumAttendee = maximumAttendee;
+        this.title = title;
+        this.content = content;
+        this.status = status;
+    }
+
+    public static EventInfo open(int maximumAttendee, String title, String content) {
+        return new EventInfo(maximumAttendee, title, content, EventStatus.OPEN);
+    }
+
+    public static EventInfo book(int maximumAttendee, String title, String content) {
+        return new EventInfo(maximumAttendee, title, content, EventStatus.BOOK);
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventInfo.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventInfo.java
@@ -76,4 +76,8 @@ public class EventInfo {
         status = EventStatus.OPEN;
     }
 
+    public int remainSeats(int attendedMenteeCount) {
+        return maximumAttendee - attendedMenteeCount;
+    }
+
 }

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventInfo.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventInfo.java
@@ -43,7 +43,7 @@ public class EventInfo {
     }
 
     public static EventInfo book(int maximumAttendee, String title, String content) {
-        return new EventInfo(maximumAttendee, title, content, EventStatus.BOOK);
+        return new EventInfo(maximumAttendee, title, content, EventStatus.READY);
     }
 
     public void checkAvailableApplication() {
@@ -69,8 +69,8 @@ public class EventInfo {
     }
 
     public void open() {
-        if (!status.isBook()) {
-            throw new EventException("CANNOT_OPEN", "예약한 이벤트에 한에서만 오픈 신청읋 할 수 있습니다");
+        if (!status.isReady()) {
+            throw new EventException("CANNOT_OPEN", "예약한 이벤트에 한에서만 오픈 신청을 할 수 있습니다");
         }
 
         status = EventStatus.OPEN;

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventInfo.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventInfo.java
@@ -35,4 +35,28 @@ public class EventInfo {
         return new EventInfo(maximumAttendee, title, content, EventStatus.BOOK);
     }
 
+    public void checkAvailableApplication() {
+        if (status.isClosed()) {
+            throw new EventException("NO_REMAIN_SEATS", "이미 모든 신청이 마감되었습니다");
+        }
+    }
+
+    public void close(int attendeeCount) {
+        if (attendeeCount == maximumAttendee) {
+            status = EventStatus.CLOSE;
+        }
+    }
+
+    public void reOpen(int attendeeCount) {
+        if (attendeeCount >= maximumAttendee) {
+            throw new EventException("NO_AVAILABLE_SEATS", "잔여 자리가 없어서 재 오픈이 불가능합니다");
+        }
+
+        status = EventStatus.REOPEN;
+    }
+
+    public void open() {
+        this.status = EventStatus.OPEN;
+    }
+
 }

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventInfo.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventInfo.java
@@ -6,9 +6,12 @@ import lombok.NoArgsConstructor;
 import org.devcourse.resumeme.domain.event.exception.EventException;
 
 import static jakarta.persistence.EnumType.STRING;
+import static lombok.AccessLevel.PROTECTED;
+import static org.devcourse.resumeme.common.util.Validator.Condition.isBlank;
+import static org.devcourse.resumeme.common.util.Validator.validate;
 
 @Embeddable
-@NoArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
 public class EventInfo {
 
     private int maximumAttendee;
@@ -21,10 +24,18 @@ public class EventInfo {
     private EventStatus status;
 
     private EventInfo(int maximumAttendee, String title, String content, EventStatus status) {
+        validateInput(maximumAttendee, title, content);
+
         this.maximumAttendee = maximumAttendee;
         this.title = title;
         this.content = content;
         this.status = status;
+    }
+
+    private void validateInput(int maximumAttendee, String title, String content) {
+        validate(maximumAttendee < 2 || maximumAttendee > 10, "RANGE_MAXIMUM_ATTENDEE", "참여 인원 수를 2~10명 사이에서 정해주세요");
+        validate(isBlank(title), "NO_EMPTY_STRING", "제목은 필수 값입니다");
+        validate(isBlank(content), "NO_EMPTY_STRING", "내용은 필수 값입니다");
     }
 
     public static EventInfo open(int maximumAttendee, String title, String content) {
@@ -41,10 +52,12 @@ public class EventInfo {
         }
     }
 
-    public void close(int attendeeCount) {
+    public int close(int attendeeCount) {
         if (attendeeCount == maximumAttendee) {
             status = EventStatus.CLOSE;
         }
+
+        return maximumAttendee - attendeeCount;
     }
 
     public void reOpen(int attendeeCount) {

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventInfo.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventInfo.java
@@ -69,7 +69,11 @@ public class EventInfo {
     }
 
     public void open() {
-        this.status = EventStatus.OPEN;
+        if (!status.isBook()) {
+            throw new EventException("CANNOT_OPEN", "예약한 이벤트에 한에서만 오픈 신청읋 할 수 있습니다");
+        }
+
+        status = EventStatus.OPEN;
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventInfo.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventInfo.java
@@ -47,7 +47,7 @@ public class EventInfo {
     }
 
     public void checkAvailableApplication() {
-        if (status.isClosed()) {
+        if (!status.canApply()) {
             throw new EventException("NO_REMAIN_SEATS", "이미 모든 신청이 마감되었습니다");
         }
     }

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventPosition.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventPosition.java
@@ -2,20 +2,30 @@ package org.devcourse.resumeme.domain.event;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.NoArgsConstructor;
+import org.devcourse.resumeme.common.domain.Position;
 
+import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+import static org.devcourse.resumeme.common.util.Validator.validate;
 
 @Entity
+@NoArgsConstructor(access = PROTECTED)
 public class EventPosition {
 
     @Id
     @GeneratedValue
     @Column(name = "event_position_id")
     private Long id;
+
+    @Enumerated(STRING)
+    private Position position;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "event_id")

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventPosition.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventPosition.java
@@ -1,0 +1,24 @@
+package org.devcourse.resumeme.domain.event;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+public class EventPosition {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "event_position_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "event_id")
+    private Event event;
+
+}

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventPosition.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventPosition.java
@@ -21,4 +21,12 @@ public class EventPosition {
     @JoinColumn(name = "event_id")
     private Event event;
 
+    public EventPosition(Position position, Event event) {
+        validate(position == null, "NO_EMPTY_VALUE", "포지션은 필수 값입니다");
+        validate(event == null, "NO_EMPTY_VALUE", "이벤트는 필수 값입니다");
+
+        this.position = position;
+        this.event = event;
+    }
+
 }

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventStatus.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventStatus.java
@@ -26,8 +26,8 @@ public enum EventStatus implements DocsEnumType {
         return description;
     }
 
-    public boolean isClosed() {
-        return this.equals(CLOSE);
+    public boolean canApply() {
+        return this.equals(OPEN) || this.equals(REOPEN);
     }
 
     public boolean isReady() {

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventStatus.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventStatus.java
@@ -30,4 +30,7 @@ public enum EventStatus implements DocsEnumType {
         return this.equals(CLOSE);
     }
 
+    public boolean isBook() {
+        return this.equals(BOOK);
+    }
 }

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventStatus.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventStatus.java
@@ -3,7 +3,7 @@ package org.devcourse.resumeme.domain.event;
 import org.devcourse.resumeme.common.domain.DocsEnumType;
 
 public enum EventStatus implements DocsEnumType {
-    BOOK("첨삭 이벤트 오픈 예약"),
+    READY("첨삭 이벤트 오픈 예약"),
     OPEN("첨삭 이벤트 오픈"),
     REOPEN("재 신청 시작"),
     CLOSE("이벤트 신청 마감"),
@@ -30,7 +30,7 @@ public enum EventStatus implements DocsEnumType {
         return this.equals(CLOSE);
     }
 
-    public boolean isBook() {
-        return this.equals(BOOK);
+    public boolean isReady() {
+        return this.equals(READY);
     }
 }

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventStatus.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventStatus.java
@@ -3,9 +3,11 @@ package org.devcourse.resumeme.domain.event;
 import org.devcourse.resumeme.common.domain.DocsEnumType;
 
 public enum EventStatus implements DocsEnumType {
+    BOOK("첨삭 이벤트 오픈 예약"),
     OPEN("첨삭 이벤트 오픈"),
     REOPEN("재 신청 시작"),
-    CLOSE("이벤트 신청 마감")
+    CLOSE("이벤트 신청 마감"),
+    FINISH("이벤트 종료")
     ;
 
     private final String description;
@@ -23,4 +25,9 @@ public enum EventStatus implements DocsEnumType {
     public String getDescription() {
         return description;
     }
+
+    public boolean isClosed() {
+        return this.equals(CLOSE);
+    }
+
 }

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventTimeInfo.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventTimeInfo.java
@@ -1,0 +1,38 @@
+package org.devcourse.resumeme.domain.event;
+
+import jakarta.persistence.Embeddable;
+import lombok.NoArgsConstructor;
+import org.devcourse.resumeme.domain.event.exception.EventException;
+
+import java.time.LocalDateTime;
+
+@Embeddable
+@NoArgsConstructor
+public class EventTimeInfo {
+
+    private LocalDateTime openDateTime;
+
+    private LocalDateTime endDate;
+
+    private EventTimeInfo(LocalDateTime openDateTime, LocalDateTime endDate) {
+        this.openDateTime = openDateTime;
+        this.endDate = endDate;
+    }
+
+    public static EventTimeInfo onStart(LocalDateTime endDate) {
+        return new EventTimeInfo(LocalDateTime.now(), endDate);
+    }
+
+    public static EventTimeInfo book(LocalDateTime openDateTime, LocalDateTime endDate) {
+        if (openDateTime.isBefore(LocalDateTime.now())) {
+            throw new EventException("CAN_NOT_RESERVATION", "현재 시간보다 이전 시간으로는 예약할 수 없습니다");
+        }
+
+        return new EventTimeInfo(openDateTime, endDate);
+    }
+
+    public boolean isAfterOpenTime(LocalDateTime nowDateTime) {
+        return nowDateTime.isAfter(this.openDateTime);
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventTimeInfo.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventTimeInfo.java
@@ -6,8 +6,11 @@ import org.devcourse.resumeme.domain.event.exception.EventException;
 
 import java.time.LocalDateTime;
 
+import static lombok.AccessLevel.PROTECTED;
+import static org.devcourse.resumeme.common.util.Validator.validate;
+
 @Embeddable
-@NoArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
 public class EventTimeInfo {
 
     private LocalDateTime openDateTime;
@@ -15,8 +18,16 @@ public class EventTimeInfo {
     private LocalDateTime endDate;
 
     private EventTimeInfo(LocalDateTime openDateTime, LocalDateTime endDate) {
+        validateInput(openDateTime, endDate);
+
         this.openDateTime = openDateTime;
         this.endDate = endDate;
+    }
+
+    private void validateInput(LocalDateTime openDateTime, LocalDateTime endDate) {
+        validate(openDateTime == null, "NO_EMPTY_VALUE", "시작 시간은 빈 값일 수 없습니다");
+        validate(endDate == null, "NO_EMPTY_VALUE", "종료 시간은 빈 값일 수 없습니다");
+        validate(openDateTime.isAfter(endDate), "TIME_ERROR", "시작 시간이 종료 시간보다 빨라야 합니다");
     }
 
     public static EventTimeInfo onStart(LocalDateTime endDate) {

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventTimeInfo.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventTimeInfo.java
@@ -30,12 +30,13 @@ public class EventTimeInfo {
         validate(openDateTime.isAfter(endDate), "TIME_ERROR", "시작 시간이 종료 시간보다 빨라야 합니다");
     }
 
-    public static EventTimeInfo onStart(LocalDateTime endDate) {
-        return new EventTimeInfo(LocalDateTime.now(), endDate);
+    public static EventTimeInfo onStart(LocalDateTime nowDateTime, LocalDateTime endDate) {
+        return new EventTimeInfo(nowDateTime, endDate);
     }
 
-    public static EventTimeInfo book(LocalDateTime openDateTime, LocalDateTime endDate) {
-        if (openDateTime.isBefore(LocalDateTime.now())) {
+    public static EventTimeInfo book(LocalDateTime nowDateTime, LocalDateTime openDateTime, LocalDateTime endDate) {
+        validate(openDateTime == null, "NO_EMPTY_VALUE", "시작 시간은 빈 값일 수 없습니다");
+        if (openDateTime.isBefore(nowDateTime)) {
             throw new EventException("CAN_NOT_RESERVATION", "현재 시간보다 이전 시간으로는 예약할 수 없습니다");
         }
 

--- a/src/main/java/org/devcourse/resumeme/domain/event/MenteeToEvent.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/MenteeToEvent.java
@@ -10,9 +10,11 @@ import lombok.NoArgsConstructor;
 import org.devcourse.resumeme.common.domain.BaseEntity;
 
 import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+import static org.devcourse.resumeme.common.util.Validator.validate;
 
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
 public class MenteeToEvent extends BaseEntity {
 
     @Id
@@ -27,6 +29,9 @@ public class MenteeToEvent extends BaseEntity {
     private Long menteeId;
 
     public MenteeToEvent(Event event, Long menteeId) {
+        validate(event == null, "NOT_EMPTY_VALUE", "이벤트는 빈 값일 수 없습니다");
+        validate(menteeId == null, "NOT_EMPTY_VALUE", "멘티는 빈 값일 수 없습니다");
+
         this.event = event;
         this.menteeId = menteeId;
     }

--- a/src/main/java/org/devcourse/resumeme/domain/event/MenteeToEvent.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/MenteeToEvent.java
@@ -1,20 +1,23 @@
 package org.devcourse.resumeme.domain.event;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.NoArgsConstructor;
+import org.devcourse.resumeme.common.domain.BaseEntity;
 
 import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
 @NoArgsConstructor
-public class MenteeToEvent {
+public class MenteeToEvent extends BaseEntity {
 
     @Id
     @GeneratedValue
+    @Column(name = "mentee_to_event_id")
     private Long id;
 
     @ManyToOne(fetch = LAZY)

--- a/src/main/java/org/devcourse/resumeme/domain/event/MenteeToEvent.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/MenteeToEvent.java
@@ -31,4 +31,8 @@ public class MenteeToEvent extends BaseEntity {
         this.menteeId = menteeId;
     }
 
+    public boolean isSameMentee(Long menteeId) {
+        return this.menteeId.equals(menteeId);
+    }
+
 }

--- a/src/main/java/org/devcourse/resumeme/domain/event/exception/EventException.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/exception/EventException.java
@@ -1,0 +1,11 @@
+package org.devcourse.resumeme.domain.event.exception;
+
+import org.devcourse.resumeme.global.advice.exception.CustomException;
+
+public class EventException extends CustomException {
+
+    public EventException(String code, String message) {
+        super(code, message);
+    }
+
+}

--- a/src/test/java/org/devcourse/resumeme/domain/event/EventInfoTest.java
+++ b/src/test/java/org/devcourse/resumeme/domain/event/EventInfoTest.java
@@ -1,0 +1,185 @@
+package org.devcourse.resumeme.domain.event;
+
+import org.devcourse.resumeme.domain.event.exception.EventException;
+import org.devcourse.resumeme.global.advice.exception.CustomException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.devcourse.resumeme.domain.event.EventStatus.CLOSE;
+import static org.devcourse.resumeme.domain.event.EventStatus.OPEN;
+import static org.devcourse.resumeme.domain.event.EventStatus.REOPEN;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class EventInfoTest {
+
+    @Test
+    void 이벤트_생성에_성공한다() {
+        // given
+        EventInfo openEvent = EventInfo.open(3, "제목", "내용");
+        EventInfo bookEvent = EventInfo.book(3, "제목", "내용");
+
+        // then
+        assertThat(openEvent).usingRecursiveComparison()
+                .comparingOnlyFields("status")
+                .isEqualTo(OPEN);
+
+        assertThat(bookEvent).usingRecursiveComparison()
+                .comparingOnlyFields("status")
+                .isEqualTo(CLOSE);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 11})
+    void 이벤트_생성_검증조건_미달로인해_생성에_실패한다_최대참석자수_범위_오류(int maximumAttendee) {
+        // then
+        assertThatThrownBy(() -> EventInfo.open(maximumAttendee, "제목", "내용"))
+                .isInstanceOf(CustomException.class);
+
+        assertThatThrownBy(() -> EventInfo.book(maximumAttendee, "제목", "내용"))
+                .isInstanceOf(CustomException.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("titleAndContent")
+    void 이벤트_생성_검증조건_미달로인해_생성에_실패한다_제목_내용_오류(String title, String content) {
+        // then
+        assertThatThrownBy(() -> EventInfo.open(3, title, content))
+                .isInstanceOf(CustomException.class);
+
+        assertThatThrownBy(() -> EventInfo.book(3, title, content))
+                .isInstanceOf(CustomException.class);
+    }
+
+    static Stream<Arguments> titleAndContent() {
+        return Stream.of(
+                Arguments.of("제목", ""),
+                Arguments.of("", "내용"),
+                Arguments.of("제목", null),
+                Arguments.of(null, "내용"),
+                Arguments.of(null, null)
+        );
+    }
+
+    @Test
+    void 아직_이벤트가_오픈상태이다() {
+        // given
+        EventInfo eventInfo = EventInfo.open(3, "제목", "내용");
+
+        // when
+        eventInfo.checkAvailableApplication();
+
+        //then
+        assertThat(eventInfo).usingRecursiveComparison()
+                .comparingOnlyFields("status")
+                .isEqualTo(OPEN);
+    }
+
+    @Test
+    void 이벤트가_마감상태이므로_예외를_반환한다() {
+        // given
+        EventInfo eventInfo = EventInfo.open(3, "제목", "내용");
+
+        // when
+        eventInfo.close(3);
+
+        // then
+        assertThatThrownBy(eventInfo::checkAvailableApplication)
+                .isInstanceOf(EventException.class);
+        assertThat(eventInfo).usingRecursiveComparison()
+                .comparingOnlyFields("status")
+                .isEqualTo(CLOSE);
+    }
+
+    @Test
+    void 아직_잔여자리가_남아있어_이벤트를_오픈상태로_유지한다() {
+        // given
+        EventInfo eventInfo = EventInfo.open(3, "제목", "내용");
+
+        // when
+        int remainSeats = eventInfo.close(1);
+
+        // then
+        assertThat(remainSeats).isEqualTo(2);
+        assertThat(eventInfo).usingRecursiveComparison()
+                .comparingOnlyFields("status")
+                .isEqualTo(OPEN);
+    }
+
+    @Test
+    void 잔여자리가_없어_이벤트를_마감상태로_변경한다() {
+        // given
+        EventInfo eventInfo = EventInfo.open(3, "제목", "내용");
+
+        // when
+        int remainSeats = eventInfo.close(3);
+
+        // then
+        assertThat(remainSeats).isZero();
+        assertThat(eventInfo).usingRecursiveComparison()
+                .comparingOnlyFields("staus")
+                .isEqualTo(CLOSE);
+    }
+
+    @Test
+    void 멘토의_요청으로인해_이벤트모집이_재오픈상태로_변경된다() {
+        // given
+        EventInfo eventInfo = EventInfo.open(3, "제목", "내용");
+        eventInfo.close(3);
+
+        // when
+        eventInfo.reOpen(2);
+
+        // then
+        assertThat(eventInfo).usingRecursiveComparison()
+                .comparingOnlyFields("status")
+                .isEqualTo(REOPEN);
+    }
+
+    @Test
+    void 잔여_자리가_없어_재오픈_요청에_대해_예외를_반환한다() {
+        // given
+        EventInfo eventInfo = EventInfo.open(3, "제목", "내용");
+        eventInfo.close(3);
+
+        // when & then
+        assertThatThrownBy(() -> eventInfo.reOpen(3))
+                .isInstanceOf(EventException.class);
+        assertThat(eventInfo).usingRecursiveComparison()
+                .comparingOnlyFields("status")
+                .isEqualTo(CLOSE);
+    }
+
+    @Test
+    void 예약한_이벤트를_오픈상태로_변경한다() {
+        // given
+        EventInfo eventInfo = EventInfo.book(3, "제목", "내용");
+
+        // when
+        eventInfo.open();
+
+        // then
+        assertThat(eventInfo).usingRecursiveComparison()
+                .comparingOnlyFields("status")
+                .isEqualTo(OPEN);
+    }
+
+    @Test
+    void 예약한_이벤트가_아니므로_오픈상태로_변경시_예외를_발생한다() {
+        // given
+        EventInfo eventInfo = EventInfo.open(3, "제목", "내용");
+
+        // when & then
+        assertThatThrownBy(eventInfo::open)
+                .isInstanceOf(EventException.class);
+    }
+
+}

--- a/src/test/java/org/devcourse/resumeme/domain/event/EventPositionTest.java
+++ b/src/test/java/org/devcourse/resumeme/domain/event/EventPositionTest.java
@@ -1,0 +1,36 @@
+package org.devcourse.resumeme.domain.event;
+
+import org.devcourse.resumeme.common.domain.Position;
+import org.devcourse.resumeme.domain.metor.Mentor;
+import org.devcourse.resumeme.global.advice.exception.CustomException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EventPositionTest {
+
+    @ParameterizedTest
+    @MethodSource("positionAndEvent")
+    void 이벤트포지션_생성_검증조건_미달로인해_생성에_실패한다_null입력_오류(Position position, Event event) {
+        // then
+        assertThatThrownBy(() -> new EventPosition(position, event))
+                .isInstanceOf(CustomException.class);
+    }
+
+    static Stream<Arguments> positionAndEvent() {
+        EventInfo openEvent = EventInfo.open(3, "제목", "내용");
+        EventTimeInfo eventTimeInfo = EventTimeInfo.onStart(LocalDateTime.now().plusHours(2L));
+        return Stream.of(
+                Arguments.of(Position.BACK, null),
+                Arguments.of(null, new Event(openEvent, eventTimeInfo, new Mentor(), List.of())),
+                Arguments.of(null, null)
+        );
+    }
+
+}

--- a/src/test/java/org/devcourse/resumeme/domain/event/EventPositionTest.java
+++ b/src/test/java/org/devcourse/resumeme/domain/event/EventPositionTest.java
@@ -25,7 +25,7 @@ class EventPositionTest {
 
     static Stream<Arguments> positionAndEvent() {
         EventInfo openEvent = EventInfo.open(3, "제목", "내용");
-        EventTimeInfo eventTimeInfo = EventTimeInfo.onStart(LocalDateTime.now().plusHours(2L));
+        EventTimeInfo eventTimeInfo = EventTimeInfo.onStart(LocalDateTime.now(), LocalDateTime.now().plusHours(2L));
         return Stream.of(
                 Arguments.of(Position.BACK, null),
                 Arguments.of(null, new Event(openEvent, eventTimeInfo, new Mentor(), List.of())),

--- a/src/test/java/org/devcourse/resumeme/domain/event/EventTest.java
+++ b/src/test/java/org/devcourse/resumeme/domain/event/EventTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -29,7 +28,7 @@ class EventTest {
     @Test
     void 이벤트_신청에_성공후_잔여석을_반환한다() {
         // when
-        int remainSeats = event.applicationToEvent(1L);
+        int remainSeats = event.acceptMentee(1L);
 
         // then
         assertThat(remainSeats).isEqualTo(2);
@@ -38,30 +37,30 @@ class EventTest {
     @Test
     void 잔여석이_남지않아서_이벤트신청에_실패한다() {
         // given
-        event.applicationToEvent(1L);
-        event.applicationToEvent(2L);
-        event.applicationToEvent(3L);
+        event.acceptMentee(1L);
+        event.acceptMentee(2L);
+        event.acceptMentee(3L);
 
         // when & then
-        assertThatThrownBy(() -> event.applicationToEvent(4L))
+        assertThatThrownBy(() -> event.acceptMentee(4L))
                 .isInstanceOf(EventException.class);
     }
 
     @Test
     void 중복신청으로_이벤트신청에_실패한다() {
         // given
-        event.applicationToEvent(1L);
+        event.acceptMentee(1L);
 
         // when & then
-        assertThatThrownBy(() -> event.applicationToEvent(1L))
+        assertThatThrownBy(() -> event.acceptMentee(1L))
                 .isInstanceOf(EventException.class);
     }
 
     @Test
     void 멘토는_멘티의_신청을_반려할수있다() {
         // given
-        event.applicationToEvent(1L);
-        event.applicationToEvent(2L);
+        event.acceptMentee(1L);
+        event.acceptMentee(2L);
 
         // when
         int remainSeats = event.reject(1L);
@@ -73,9 +72,9 @@ class EventTest {
     @Test
     void 잔여석이_생겨서_재오픈에_성공한다() {
         // given
-        event.applicationToEvent(1L);
-        event.applicationToEvent(2L);
-        event.applicationToEvent(3L);
+        event.acceptMentee(1L);
+        event.acceptMentee(2L);
+        event.acceptMentee(3L);
         event.reject(1L);
 
         // when
@@ -88,9 +87,9 @@ class EventTest {
     @Test
     void 잔여석이_없어_재오픈_신청에_실패한다() {
         // given
-        event.applicationToEvent(1L);
-        event.applicationToEvent(2L);
-        event.applicationToEvent(3L);
+        event.acceptMentee(1L);
+        event.acceptMentee(2L);
+        event.acceptMentee(3L);
 
         // when & then
         assertThatThrownBy(() -> event.reOpenEvent())

--- a/src/test/java/org/devcourse/resumeme/domain/event/EventTest.java
+++ b/src/test/java/org/devcourse/resumeme/domain/event/EventTest.java
@@ -1,0 +1,112 @@
+package org.devcourse.resumeme.domain.event;
+
+import org.devcourse.resumeme.domain.event.exception.EventException;
+import org.devcourse.resumeme.domain.metor.Mentor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class EventTest {
+
+    private Event event;
+
+    @BeforeEach
+    void init() {
+        EventInfo openEvent = EventInfo.open(3, "제목", "내용");
+        EventTimeInfo eventTimeInfo = EventTimeInfo.onStart(LocalDateTime.now(), LocalDateTime.now().plusHours(2L));
+        event = new Event(openEvent, eventTimeInfo, new Mentor(), List.of());
+    }
+
+    @Test
+    void 이벤트_신청에_성공후_잔여석을_반환한다() {
+        // when
+        int remainSeats = event.applicationToEvent(1L);
+
+        // then
+        assertThat(remainSeats).isEqualTo(2);
+    }
+
+    @Test
+    void 잔여석이_남지않아서_이벤트신청에_실패한다() {
+        // given
+        event.applicationToEvent(1L);
+        event.applicationToEvent(2L);
+        event.applicationToEvent(3L);
+
+        // when & then
+        assertThatThrownBy(() -> event.applicationToEvent(4L))
+                .isInstanceOf(EventException.class);
+    }
+
+    @Test
+    void 중복신청으로_이벤트신청에_실패한다() {
+        // given
+        event.applicationToEvent(1L);
+
+        // when & then
+        assertThatThrownBy(() -> event.applicationToEvent(1L))
+                .isInstanceOf(EventException.class);
+    }
+
+    @Test
+    void 멘토는_멘티의_신청을_반려할수있다() {
+        // given
+        event.applicationToEvent(1L);
+        event.applicationToEvent(2L);
+
+        // when
+        int remainSeats = event.reject(1L);
+
+        // then
+        assertThat(remainSeats).isEqualTo(2);
+    }
+
+    @Test
+    void 잔여석이_생겨서_재오픈에_성공한다() {
+        // given
+        event.applicationToEvent(1L);
+        event.applicationToEvent(2L);
+        event.applicationToEvent(3L);
+        event.reject(1L);
+
+        // when
+        int remainSeats = event.reOpenEvent();
+
+        // then
+        assertThat(remainSeats).isEqualTo(1);
+    }
+
+    @Test
+    void 잔여석이_없어_재오픈_신청에_실패한다() {
+        // given
+        event.applicationToEvent(1L);
+        event.applicationToEvent(2L);
+        event.applicationToEvent(3L);
+
+        // when & then
+        assertThatThrownBy(() -> event.reOpenEvent())
+                .isInstanceOf(EventException.class);
+    }
+
+    @Test
+    void 오픈예약한_시간이_아니라서_이벤트_오픈에_실패한다() {
+        // given
+        EventInfo openEvent = EventInfo.book(3, "제목", "내용");
+        EventTimeInfo eventTimeInfo = EventTimeInfo.book(LocalDateTime.now(), LocalDateTime.now().plusHours(2L), LocalDateTime.now().plusHours(4L));
+        Event bookEvent = new Event(openEvent, eventTimeInfo, new Mentor(), List.of());
+
+        // when & then
+        assertThatThrownBy(() -> bookEvent.openReservationEvent(LocalDateTime.now()))
+                .isInstanceOf(EventException.class);
+    }
+
+}

--- a/src/test/java/org/devcourse/resumeme/domain/event/EventTimeInfoTest.java
+++ b/src/test/java/org/devcourse/resumeme/domain/event/EventTimeInfoTest.java
@@ -1,0 +1,59 @@
+package org.devcourse.resumeme.domain.event;
+
+import org.devcourse.resumeme.domain.event.exception.EventException;
+import org.devcourse.resumeme.global.advice.exception.CustomException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class EventTimeInfoTest {
+
+    @Test
+    void 이벤트_시간정보_생성에_성공한다() {
+        // given
+        EventTimeInfo onStart = EventTimeInfo.onStart(LocalDateTime.now(), LocalDateTime.now().plusHours(1));
+        EventTimeInfo book = EventTimeInfo.book(LocalDateTime.now(), LocalDateTime.now().plusHours(1), LocalDateTime.now().plusHours(2));
+
+        // then
+        assertThat(onStart).isNotNull();
+        assertThat(book).isNotNull();
+    }
+
+    @Test
+    void 이벤트_시간_예약시_오픈시간이_현재시간보다_빠르면_예약에_실패한다() {
+        // then
+        assertThatThrownBy(() -> EventTimeInfo.book(LocalDateTime.now(), LocalDateTime.now().minusSeconds(1), LocalDateTime.now().plusHours(1)))
+                .isInstanceOf(EventException.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("timeInfo")
+    void 이벤트_시간_생성_검증조건에_실패하여_생성에_실패한다(LocalDateTime openDateTime, LocalDateTime endDate) {
+        // then
+        assertThatThrownBy(() -> EventTimeInfo.onStart(LocalDateTime.now(), endDate))
+                .isInstanceOf(CustomException.class);
+
+        assertThatThrownBy(() -> EventTimeInfo.book(LocalDateTime.now(), openDateTime, endDate))
+                .isInstanceOf(CustomException.class);
+    }
+
+    static Stream<Arguments> timeInfo() {
+        return Stream.of(
+                Arguments.of(null, null),
+                Arguments.of(LocalDateTime.now(), null),
+                Arguments.of(null, LocalDateTime.now()),
+                Arguments.of(LocalDateTime.now().plusHours(2), LocalDateTime.now().minusHours(1))
+        );
+    }
+
+}

--- a/src/test/java/org/devcourse/resumeme/domain/event/MenteeToEventTest.java
+++ b/src/test/java/org/devcourse/resumeme/domain/event/MenteeToEventTest.java
@@ -1,0 +1,73 @@
+package org.devcourse.resumeme.domain.event;
+
+import org.devcourse.resumeme.domain.metor.Mentor;
+import org.devcourse.resumeme.global.advice.exception.CustomException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class MenteeToEventTest {
+
+    @Test
+    void 멘티와_이벤트를_연결하는_연관관계테이블_객체_생성에_성공한다() {
+        // given
+        EventInfo openEvent = EventInfo.open(3, "제목", "내용");
+        EventTimeInfo eventTimeInfo = EventTimeInfo.onStart(LocalDateTime.now(), LocalDateTime.now().plusHours(2L));
+        MenteeToEvent menteeToEvent = new MenteeToEvent(new Event(openEvent, eventTimeInfo, new Mentor(), List.of()), 1L);
+
+        // then
+        assertThat(menteeToEvent).isNotNull();
+    }
+
+    @ParameterizedTest
+    @MethodSource("eventMenteeID")
+    void 멘티와_이벤트를_연결하는_연관관계테이블_객체_생성에_실패한다_검증조건실패(Event event, Long menteeId) {
+        // then
+        assertThatThrownBy(() -> new MenteeToEvent(event, menteeId))
+                .isInstanceOf(CustomException.class);
+    }
+
+    static Stream<Arguments> eventMenteeID() {
+        EventInfo openEvent = EventInfo.open(3, "제목", "내용");
+        EventTimeInfo eventTimeInfo = EventTimeInfo.onStart(LocalDateTime.now(), LocalDateTime.now().plusHours(2L));
+        return Stream.of(
+                Arguments.of(null, null),
+                Arguments.of(null, 1L),
+                Arguments.of(new Event(openEvent, eventTimeInfo, new Mentor(), List.of()), null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("sameMentee")
+    void 현재_신청한_멘티와_일치여부를_확인한다(Long menteeId, boolean result) {
+        // given
+        EventInfo openEvent = EventInfo.open(3, "제목", "내용");
+        EventTimeInfo eventTimeInfo = EventTimeInfo.onStart(LocalDateTime.now(), LocalDateTime.now().plusHours(2L));
+        MenteeToEvent menteeToEvent = new MenteeToEvent(new Event(openEvent, eventTimeInfo, new Mentor(), List.of()), 1L);
+
+        // when
+        boolean sameMentee = menteeToEvent.isSameMentee(menteeId);
+
+        // then
+        assertThat(sameMentee).isEqualTo(result);
+    }
+
+    static Stream<Arguments> sameMentee() {
+        return Stream.of(
+                Arguments.of(1L, true),
+                Arguments.of(2L, false)
+        );
+    }
+
+}


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
프론트와 협의후 도메인 변경된 부분 수정
도메인 메소드 도출

- Event : 멘토가 여는 이력서 첨삭 이벤트
    - EventInfo
    - EventTimeInfo
- EventPosition : 첨삭 이벤트에 들어가는 포지션들(백, 프론트...)
- MenteeToEvent : 첨삭 이벤트에 신청한 멘티 리스트 (Event와 다대일 관계)

## CC. 리뷰어
이전 pr 브랜치 잘못 설정해서 닫았다가 다시 pr올렸습니다

## 테스트 설명
Event, EventInfo, EventPosition, EventTimeInfo, MenteeToEvent 도메인 관련 5개 테스트 파일 포합입니다

## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
