### PR TITLE
fix: endpoint 설정 http method 추가

### DIFF
--- a/src/main/java/org/devcourse/resumeme/global/config/EndpointProperties.java
+++ b/src/main/java/org/devcourse/resumeme/global/config/EndpointProperties.java
@@ -10,14 +10,28 @@ import java.util.Map;
 public class EndpointProperties {
 
     @Getter
-    private List<String> permitAll;
+    private Map<String, List<String>> permitAll;
 
     @Getter
-    private Map<String, List<String>> roles;
+    private List<Matcher> roles;
 
-    public EndpointProperties(List<String> permitAll, Map<String, List<String>> roles) {
+    public EndpointProperties(Map<String, List<String>> permitAll, List<Matcher> roles) {
         this.permitAll = permitAll;
         this.roles = roles;
     }
 
+    public static class Matcher {
+
+        @Getter
+        private Map<String, List<String>> matcher;
+
+        @Getter
+        private List<String> role;
+
+        public Matcher(Map<String, List<String>> matcher, List<String> role) {
+            this.matcher = matcher;
+            this.role = role;
+        }
+
+    }
 }

--- a/src/main/java/org/devcourse/resumeme/global/config/SecurityConfig.java
+++ b/src/main/java/org/devcourse/resumeme/global/config/SecurityConfig.java
@@ -6,8 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
-import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 import java.util.List;
 import java.util.Map;
@@ -20,8 +19,6 @@ public class SecurityConfig {
 
     private final EndpointProperties properties;
 
-    private final HandlerMappingIntrospector introspector;
-
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         setEndpoints(http);
@@ -33,18 +30,27 @@ public class SecurityConfig {
     }
 
     private void setEndpoints(HttpSecurity http) throws Exception {
-        for (String endpoint : properties.getPermitAll()) {
-            http.authorizeHttpRequests(registry ->
-                    registry.requestMatchers(new MvcRequestMatcher(introspector, endpoint)).permitAll()
-            );
+        for (Map.Entry<String, List<String>> entry : properties.getPermitAll().entrySet()) {
+            String method = entry.getKey();
+
+            for (String endPoint : entry.getValue()) {
+                http.authorizeHttpRequests(registry ->
+                        registry.requestMatchers(new AntPathRequestMatcher(endPoint, method)).permitAll());
+            }
         }
 
-        for (Map.Entry<String, List<String>> entry : properties.getRoles().entrySet()) {
-            String roleName = entry.getKey();
+        for (EndpointProperties.Matcher role : properties.getRoles()) {
+            String[] roles = role.getRole().stream()
+                    .map(String::toUpperCase)
+                    .toArray(String[]::new);
 
-            for (String endpoint : entry.getValue()) {
-                http.authorizeHttpRequests(registry ->
-                        registry.requestMatchers(new MvcRequestMatcher(introspector, endpoint)).hasRole(roleName.toUpperCase()));
+            for (Map.Entry<String, List<String>> entry : role.getMatcher().entrySet()) {
+                String method = entry.getKey();
+
+                for (String endPoint : entry.getValue()) {
+                    http.authorizeHttpRequests(registry ->
+                            registry.requestMatchers(new AntPathRequestMatcher(endPoint, method)).hasAnyRole(roles));
+                }
             }
         }
     }

--- a/src/main/resources/application-endpoint.yml
+++ b/src/main/resources/application-endpoint.yml
@@ -1,6 +1,22 @@
 endpoint:
-  permitAll:
+  permit-all:
+    get: /api/v1/user
+    post:
+    put:
+    patch:
+    delete:
   roles:
-    user:
-    mento:
-    mentee:
+    - matcher:
+        get: /api/v1/user
+        post:
+        put:
+        patch:
+        delete:
+      role: user, mentor
+    - matcher:
+        get: /api/v1/user
+        post:
+        put:
+        patch:
+        delete:
+      role: mentor


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
기존에는 http method가 없었던 endPoint yml 파일 양식 수정했습니다
role에 대해서도 여러 role을 설정 할 수 있도록 변경했습니다

```yaml
  roles:
    - matcher:
        get: /api/v1/user
        post:
        put:
        patch:
        delete:
      role: user, mentor 

# user만 작성해도 되고 user, mentor, 기타 여러 role을 작성해도 됩니다
# 지금은 모든 method를 작성 해뒀지만 필요없으면 나중에 endpoint가 없는 것은 제거해도 됩니다
```
**수정이유**
http method가 없어 GET `/api/v1/users`와 POST `/api/v1/users`를 구분을 할 수 없었습니다

## CC. 리뷰어
기존에 정리해뒀던 노션에도 추후 수정해서 설명 반영해두겠습니다

## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
