### PR TITLE
feat: 첨삭 이벤트 참여 기능 구현입니다

### DIFF
--- a/src/main/java/org/devcourse/resumeme/controller/EventController.java
+++ b/src/main/java/org/devcourse/resumeme/controller/EventController.java
@@ -2,10 +2,15 @@ package org.devcourse.resumeme.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.devcourse.resumeme.common.response.IdResponse;
+import org.devcourse.resumeme.controller.dto.ApplyToEventRequest;
 import org.devcourse.resumeme.controller.dto.EventCreateRequest;
+import org.devcourse.resumeme.controller.dto.ValueResponse;
 import org.devcourse.resumeme.domain.event.Event;
 import org.devcourse.resumeme.domain.mentor.Mentor;
 import org.devcourse.resumeme.service.EventService;
+import org.devcourse.resumeme.service.vo.AcceptMenteeToEvent;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,6 +30,14 @@ public class EventController {
         Event event = request.toEntity(mentor);
 
         return new IdResponse(eventService.create(event));
+    }
+
+    @PatchMapping("/{eventId}")
+    public ValueResponse<Integer> applyEvent(@PathVariable Long eventId, @RequestBody ApplyToEventRequest request /* @AuthenticationPrincipal 인증 유저 */) {
+        /* 인증 유저 아이디 -> 멘티 아이디 찾아오기 */
+        Long menteeId = 1L;
+
+        return new ValueResponse<>(eventService.acceptMentee(new AcceptMenteeToEvent(eventId, request.resumeId(), menteeId)));
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/controller/EventController.java
+++ b/src/main/java/org/devcourse/resumeme/controller/EventController.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.devcourse.resumeme.common.response.IdResponse;
 import org.devcourse.resumeme.controller.dto.ApplyToEventRequest;
 import org.devcourse.resumeme.controller.dto.EventCreateRequest;
-import org.devcourse.resumeme.controller.dto.ValueResponse;
 import org.devcourse.resumeme.domain.event.Event;
 import org.devcourse.resumeme.domain.mentor.Mentor;
 import org.devcourse.resumeme.service.EventService;
@@ -33,11 +32,12 @@ public class EventController {
     }
 
     @PatchMapping("/{eventId}")
-    public ValueResponse<Integer> applyEvent(@PathVariable Long eventId, @RequestBody ApplyToEventRequest request /* @AuthenticationPrincipal 인증 유저 */) {
+    public IdResponse applyEvent(@PathVariable Long eventId, @RequestBody ApplyToEventRequest request /* @AuthenticationPrincipal 인증 유저 */) {
         /* 인증 유저 아이디 -> 멘티 아이디 찾아오기 */
         Long menteeId = 1L;
+        Event event = eventService.acceptMentee(new AcceptMenteeToEvent(eventId, request.resumeId(), menteeId));
 
-        return new ValueResponse<>(eventService.acceptMentee(new AcceptMenteeToEvent(eventId, request.resumeId(), menteeId)));
+        return new IdResponse(eventService.getApplicantId(event, menteeId));
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/controller/dto/ApplyToEventRequest.java
+++ b/src/main/java/org/devcourse/resumeme/controller/dto/ApplyToEventRequest.java
@@ -1,0 +1,5 @@
+package org.devcourse.resumeme.controller.dto;
+
+public record ApplyToEventRequest(Long resumeId) {
+
+}

--- a/src/main/java/org/devcourse/resumeme/controller/dto/ValueResponse.java
+++ b/src/main/java/org/devcourse/resumeme/controller/dto/ValueResponse.java
@@ -1,0 +1,5 @@
+package org.devcourse.resumeme.controller.dto;
+
+public record ValueResponse<T>(T value) {
+
+}

--- a/src/main/java/org/devcourse/resumeme/controller/dto/ValueResponse.java
+++ b/src/main/java/org/devcourse/resumeme/controller/dto/ValueResponse.java
@@ -1,5 +1,0 @@
-package org.devcourse.resumeme.controller.dto;
-
-public record ValueResponse<T>(T value) {
-
-}

--- a/src/main/java/org/devcourse/resumeme/domain/event/Event.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/Event.java
@@ -69,10 +69,10 @@ public class Event extends BaseEntity {
         validate(positions == null, "NO_EMPTY_VALUE", "빈 값일 수 없습니다");
     }
 
-    public int acceptMentee(Long menteeId) {
+    public int acceptMentee(Long menteeId, Long resumeId) {
         checkDuplicateApplicationEvent(menteeId);
         eventInfo.checkAvailableApplication();
-        applicants.add(new MenteeToEvent(this, menteeId));
+        applicants.add(new MenteeToEvent(this, menteeId, resumeId));
 
         return eventInfo.close(applicants.size());
     }

--- a/src/main/java/org/devcourse/resumeme/domain/event/Event.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/Event.java
@@ -105,4 +105,14 @@ public class Event extends BaseEntity {
         eventInfo.open();
     }
 
+    public Long getApplicantId(Long menteeId) {
+        for (MenteeToEvent applicant : applicants) {
+            if (applicant.isSameMentee(menteeId)) {
+                return applicant.getId();
+            }
+        }
+
+        throw new EventException("NOT_FOUND", "이력을 찾을 수 없습니다");
+    }
+
 }

--- a/src/main/java/org/devcourse/resumeme/domain/event/MenteeToEvent.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/MenteeToEvent.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.devcourse.resumeme.common.domain.BaseEntity;
 
@@ -18,6 +19,7 @@ import static org.devcourse.resumeme.common.util.Validator.validate;
 public class MenteeToEvent extends BaseEntity {
 
     @Id
+    @Getter
     @GeneratedValue
     @Column(name = "mentee_to_event_id")
     private Long id;

--- a/src/main/java/org/devcourse/resumeme/domain/event/MenteeToEvent.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/MenteeToEvent.java
@@ -28,12 +28,16 @@ public class MenteeToEvent extends BaseEntity {
 
     private Long menteeId;
 
-    public MenteeToEvent(Event event, Long menteeId) {
+    private Long resumeId;
+
+    public MenteeToEvent(Event event, Long menteeId, Long resumeId) {
         validate(event == null, "NOT_EMPTY_VALUE", "이벤트는 빈 값일 수 없습니다");
         validate(menteeId == null, "NOT_EMPTY_VALUE", "멘티는 빈 값일 수 없습니다");
+        validate(resumeId == null, "NOT_EMPTY_VALUE", "이력서는 빈 값일 수 없습니다");
 
         this.event = event;
         this.menteeId = menteeId;
+        this.resumeId = resumeId;
     }
 
     public boolean isSameMentee(Long menteeId) {

--- a/src/main/java/org/devcourse/resumeme/repository/EventRepository.java
+++ b/src/main/java/org/devcourse/resumeme/repository/EventRepository.java
@@ -1,8 +1,15 @@
 package org.devcourse.resumeme.repository;
 
+import jakarta.persistence.LockModeType;
 import org.devcourse.resumeme.domain.event.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+import java.util.Optional;
 
 public interface EventRepository extends JpaRepository<Event, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Event> findWithLockById(Long id);
 
 }

--- a/src/main/java/org/devcourse/resumeme/service/EventService.java
+++ b/src/main/java/org/devcourse/resumeme/service/EventService.java
@@ -18,11 +18,17 @@ public class EventService {
         return eventRepository.save(event).getId();
     }
 
-    public int acceptMentee(AcceptMenteeToEvent ids) {
+    public Event acceptMentee(AcceptMenteeToEvent ids) {
         Event event = eventRepository.findWithLockById(ids.eventId())
                 .orElseThrow();
+        event.acceptMentee(ids.menteeId(), ids.resumeId());
 
-        return event.acceptMentee(ids.menteeId(), ids.resumeId());
+        return event;
+    }
+
+    @Transactional(readOnly = true)
+    public Long getApplicantId(Event event, Long menteeId) {
+        return event.getApplicantId(menteeId);
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/service/EventService.java
+++ b/src/main/java/org/devcourse/resumeme/service/EventService.java
@@ -3,9 +3,12 @@ package org.devcourse.resumeme.service;
 import lombok.RequiredArgsConstructor;
 import org.devcourse.resumeme.domain.event.Event;
 import org.devcourse.resumeme.repository.EventRepository;
+import org.devcourse.resumeme.service.vo.AcceptMenteeToEvent;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class EventService {
 
@@ -13,6 +16,13 @@ public class EventService {
 
     public Long create(Event event) {
         return eventRepository.save(event).getId();
+    }
+
+    public int acceptMentee(AcceptMenteeToEvent ids) {
+        Event event = eventRepository.findWithLockById(ids.eventId())
+                .orElseThrow();
+
+        return event.acceptMentee(ids.menteeId(), ids.resumeId());
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/service/vo/AcceptMenteeToEvent.java
+++ b/src/main/java/org/devcourse/resumeme/service/vo/AcceptMenteeToEvent.java
@@ -1,0 +1,5 @@
+package org.devcourse.resumeme.service.vo;
+
+public record AcceptMenteeToEvent(Long eventId, Long menteeId, Long resumeId) {
+
+}

--- a/src/test/java/org/devcourse/resumeme/controller/EventControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/controller/EventControllerTest.java
@@ -6,6 +6,8 @@ import org.devcourse.resumeme.controller.dto.EventCreateRequest;
 import org.devcourse.resumeme.controller.dto.EventCreateRequest.EventInfoRequest;
 import org.devcourse.resumeme.controller.dto.EventCreateRequest.EventTimeRequest;
 import org.devcourse.resumeme.domain.event.Event;
+import org.devcourse.resumeme.domain.event.EventInfo;
+import org.devcourse.resumeme.domain.event.EventTimeInfo;
 import org.devcourse.resumeme.domain.mentor.Mentor;
 import org.devcourse.resumeme.service.vo.AcceptMenteeToEvent;
 import org.junit.jupiter.api.Test;
@@ -83,8 +85,14 @@ class EventControllerTest extends ControllerUnitTest {
     @Test
     void 첨삭_이벤트_참여에_성공한다() throws Exception {
         // given
+        EventInfo openEvent = EventInfo.open(3, "제목", "내용");
+        EventTimeInfo eventTimeInfo = EventTimeInfo.onStart(LocalDateTime.now(), LocalDateTime.now().plusHours(1L), LocalDateTime.now().plusHours(2L));
+        Event event = new Event(openEvent, eventTimeInfo, new Mentor(), List.of());
+        event.acceptMentee(1L, 1L);
+
         ApplyToEventRequest request = new ApplyToEventRequest(1L);
-        given(eventService.acceptMentee(new AcceptMenteeToEvent(1L, 1L, 1L))).willReturn(1);
+        given(eventService.acceptMentee(new AcceptMenteeToEvent(1L, 1L, 1L))).willReturn(null);
+        given(eventService.getApplicantId(event, 1L)).willReturn(1L);
 
         // when
         ResultActions result = mvc.perform(patch("/api/v1/events/{eventId}", 1L)
@@ -105,7 +113,7 @@ class EventControllerTest extends ControllerUnitTest {
                                         fieldWithPath("resumeId").type(NUMBER).description("이벤트 참여시 사용할 이력서 아이디")
                                 ),
                                 responseFields(
-                                        fieldWithPath("value").type(NUMBER).description("이벤트에 남은 좌석 수")
+                                        fieldWithPath("id").type(NUMBER).description("이벤트에 참여 성공후 발급된 이력 아이디")
                                 )
                         )
                 );

--- a/src/test/java/org/devcourse/resumeme/controller/EventControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/controller/EventControllerTest.java
@@ -1,11 +1,13 @@
 package org.devcourse.resumeme.controller;
 
 import org.devcourse.resumeme.common.ControllerUnitTest;
+import org.devcourse.resumeme.controller.dto.ApplyToEventRequest;
 import org.devcourse.resumeme.controller.dto.EventCreateRequest;
 import org.devcourse.resumeme.controller.dto.EventCreateRequest.EventInfoRequest;
 import org.devcourse.resumeme.controller.dto.EventCreateRequest.EventTimeRequest;
 import org.devcourse.resumeme.domain.event.Event;
 import org.devcourse.resumeme.domain.mentor.Mentor;
+import org.devcourse.resumeme.service.vo.AcceptMenteeToEvent;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
@@ -19,6 +21,7 @@ import static org.devcourse.resumeme.common.util.ApiDocumentUtils.getDocumentReq
 import static org.devcourse.resumeme.common.util.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
@@ -26,6 +29,8 @@ import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class EventControllerTest extends ControllerUnitTest {
@@ -70,6 +75,37 @@ class EventControllerTest extends ControllerUnitTest {
                                 ),
                                 responseFields(
                                         fieldWithPath("id").type(NUMBER).description("생성된 첨삭 이벤트 아이디")
+                                )
+                        )
+                );
+    }
+
+    @Test
+    void 첨삭_이벤트_참여에_성공한다() throws Exception {
+        // given
+        ApplyToEventRequest request = new ApplyToEventRequest(1L);
+        given(eventService.acceptMentee(new AcceptMenteeToEvent(1L, 1L, 1L))).willReturn(1);
+
+        // when
+        ResultActions result = mvc.perform(patch("/api/v1/events/{eventId}", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(request)));
+
+        // then
+        result
+                .andExpect(status().isOk())
+                .andDo(
+                        document("event/apply",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                pathParameters(
+                                        parameterWithName("eventId").description("참여하고 싶은 이벤트 아이디")
+                                ),
+                                requestFields(
+                                        fieldWithPath("resumeId").type(NUMBER).description("이벤트 참여시 사용할 이력서 아이디")
+                                ),
+                                responseFields(
+                                        fieldWithPath("value").type(NUMBER).description("이벤트에 남은 좌석 수")
                                 )
                         )
                 );

--- a/src/test/java/org/devcourse/resumeme/domain/event/EventTest.java
+++ b/src/test/java/org/devcourse/resumeme/domain/event/EventTest.java
@@ -28,7 +28,7 @@ class EventTest {
     @Test
     void 이벤트_신청에_성공후_잔여석을_반환한다() {
         // when
-        int remainSeats = event.acceptMentee(1L);
+        int remainSeats = event.acceptMentee(1L, 1L);
 
         // then
         assertThat(remainSeats).isEqualTo(2);
@@ -37,30 +37,30 @@ class EventTest {
     @Test
     void 잔여석이_남지않아서_이벤트신청에_실패한다() {
         // given
-        event.acceptMentee(1L);
-        event.acceptMentee(2L);
-        event.acceptMentee(3L);
+        event.acceptMentee(1L, 1L);
+        event.acceptMentee(2L, 1L);
+        event.acceptMentee(3L, 1L);
 
         // when & then
-        assertThatThrownBy(() -> event.acceptMentee(4L))
+        assertThatThrownBy(() -> event.acceptMentee(4L, 1L))
                 .isInstanceOf(EventException.class);
     }
 
     @Test
     void 중복신청으로_이벤트신청에_실패한다() {
         // given
-        event.acceptMentee(1L);
+        event.acceptMentee(1L, 1L);
 
         // when & then
-        assertThatThrownBy(() -> event.acceptMentee(1L))
+        assertThatThrownBy(() -> event.acceptMentee(1L, 1L))
                 .isInstanceOf(EventException.class);
     }
 
     @Test
     void 멘토는_멘티의_신청을_반려할수있다() {
         // given
-        event.acceptMentee(1L);
-        event.acceptMentee(2L);
+        event.acceptMentee(1L, 1L);
+        event.acceptMentee(2L, 1L);
 
         // when
         int remainSeats = event.reject(1L);
@@ -72,9 +72,9 @@ class EventTest {
     @Test
     void 잔여석이_생겨서_재오픈에_성공한다() {
         // given
-        event.acceptMentee(1L);
-        event.acceptMentee(2L);
-        event.acceptMentee(3L);
+        event.acceptMentee(1L, 1L);
+        event.acceptMentee(2L, 1L);
+        event.acceptMentee(3L, 1L);
         event.reject(1L);
 
         // when
@@ -87,9 +87,9 @@ class EventTest {
     @Test
     void 잔여석이_없어_재오픈_신청에_실패한다() {
         // given
-        event.acceptMentee(1L);
-        event.acceptMentee(2L);
-        event.acceptMentee(3L);
+        event.acceptMentee(1L, 1L);
+        event.acceptMentee(2L, 1L);
+        event.acceptMentee(3L, 1L);
 
         // when & then
         assertThatThrownBy(() -> event.reOpenEvent())

--- a/src/test/java/org/devcourse/resumeme/domain/event/MenteeToEventTest.java
+++ b/src/test/java/org/devcourse/resumeme/domain/event/MenteeToEventTest.java
@@ -24,7 +24,7 @@ class MenteeToEventTest {
         // given
         EventInfo openEvent = EventInfo.open(3, "제목", "내용");
         EventTimeInfo eventTimeInfo = EventTimeInfo.onStart(LocalDateTime.now(), LocalDateTime.now().plusHours(1L), LocalDateTime.now().plusHours(2L));
-        MenteeToEvent menteeToEvent = new MenteeToEvent(new Event(openEvent, eventTimeInfo, new Mentor(), List.of()), 1L);
+        MenteeToEvent menteeToEvent = new MenteeToEvent(new Event(openEvent, eventTimeInfo, new Mentor(), List.of()), 1L, 1L);
 
         // then
         assertThat(menteeToEvent).isNotNull();
@@ -34,7 +34,7 @@ class MenteeToEventTest {
     @MethodSource("eventMenteeID")
     void 멘티와_이벤트를_연결하는_연관관계테이블_객체_생성에_실패한다_검증조건실패(Event event, Long menteeId) {
         // then
-        assertThatThrownBy(() -> new MenteeToEvent(event, menteeId))
+        assertThatThrownBy(() -> new MenteeToEvent(event, menteeId, 1L))
                 .isInstanceOf(CustomException.class);
     }
 
@@ -54,7 +54,7 @@ class MenteeToEventTest {
         // given
         EventInfo openEvent = EventInfo.open(3, "제목", "내용");
         EventTimeInfo eventTimeInfo = EventTimeInfo.onStart(LocalDateTime.now(), LocalDateTime.now().plusHours(1L), LocalDateTime.now().plusHours(2L));
-        MenteeToEvent menteeToEvent = new MenteeToEvent(new Event(openEvent, eventTimeInfo, new Mentor(), List.of()), 1L);
+        MenteeToEvent menteeToEvent = new MenteeToEvent(new Event(openEvent, eventTimeInfo, new Mentor(), List.of()), 1L, 1L);
 
         // when
         boolean sameMentee = menteeToEvent.isSameMentee(menteeId);

--- a/src/test/java/org/devcourse/resumeme/service/EventServiceTest.java
+++ b/src/test/java/org/devcourse/resumeme/service/EventServiceTest.java
@@ -1,0 +1,98 @@
+package org.devcourse.resumeme.service;
+
+import org.devcourse.resumeme.domain.event.Event;
+import org.devcourse.resumeme.domain.event.EventInfo;
+import org.devcourse.resumeme.domain.event.EventTimeInfo;
+import org.devcourse.resumeme.domain.mentor.Mentor;
+import org.devcourse.resumeme.repository.EventRepository;
+import org.devcourse.resumeme.service.vo.AcceptMenteeToEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class EventServiceTest {
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @InjectMocks
+    private EventService eventService;
+
+    private ExecutorService executorService;
+
+    private CountDownLatch countDownLatch;
+
+    private AtomicInteger successCount;
+
+    private AtomicInteger failCount;
+
+    int executeCount;
+
+    @BeforeEach
+    void init() {
+        executeCount = 10;
+        executorService = Executors.newFixedThreadPool(3);
+        countDownLatch = new CountDownLatch(executeCount);
+        successCount = new AtomicInteger();
+        failCount = new AtomicInteger();
+    }
+
+    @Test
+    void 여러스레드를_이용하여_선착순으로_진행한_이벤트참여신청에_최대_참여수만큼_성공한다() throws InterruptedException {
+        // given
+        EventInfo openEvent = EventInfo.open(3, "제목", "내용");
+        EventTimeInfo eventTimeInfo = EventTimeInfo.onStart(LocalDateTime.now(), LocalDateTime.now().plusHours(1L), LocalDateTime.now().plusHours(2L));
+        Event event = new Event(openEvent, eventTimeInfo, new Mentor(), List.of());
+
+        given(eventRepository.findWithLockById(1L)).willReturn(Optional.of(event));
+
+        // when
+        for (int i = 0; i < executeCount; i++) {
+            executeThread((number) -> eventService.acceptMentee(new AcceptMenteeToEvent(1L, Long.valueOf(number), 1L)), i);
+        }
+
+        countDownLatch.await();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(3);
+        assertThat(failCount.get()).isEqualTo(executeCount - 3);
+    }
+
+    private void executeThread(Consumer<Integer> service, int number) {
+            executorService.execute(() -> {
+                try {
+                    Thread.sleep(new Random().nextLong(100));
+
+                    service.accept(number);
+
+                    successCount.getAndIncrement();
+                } catch (Exception e) {
+                    failCount.getAndIncrement();
+                    System.out.println(e.getMessage());
+                }
+                countDownLatch.countDown();
+            });
+    }
+
+}


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
첨삭 이벤트 참여 기능 구현
동시성 처리는 우선 배타락을 기반으로 구현했습니다

## CC. 리뷰어
MenteeToEvent(어떤 이벤트에 어느 멘티가 참석했는지)엔티티에 이벤트 참석 시 사용하는 이력서 아이디값이 추가가 되었습니다
ValueResponse를 만들었는데 값이 String이나 int같은거는 같이 써도 괜찮을 것 같네요

## 테스트 설명
- EventControllerTest
- EventServiceTest : 총 10명을 기준으로 Lock 적용으로 인한 동시성 확인 테스트입니다

- MenteeToEventTest, EventTest는 resumeId 필드 추가로 인한 수정입니다
## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
