### PR TITLE
feat: 소셜 회원가입 이력이 없는 사용자는 필수 추가정보 입력해야한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,10 @@ dependencies {
 	// security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'com.auth0:java-jwt:4.4.0'
 	// database
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	// encrypt yml value

--- a/src/main/java/org/devcourse/resumeme/domain/mentee/Mentee.java
+++ b/src/main/java/org/devcourse/resumeme/domain/mentee/Mentee.java
@@ -30,12 +30,6 @@ public class Mentee extends BaseEntity {
 
     @Getter
     @Column(unique = true)
-    private String oauthUsername;
-
-    @Getter
-    private String password;
-
-    @Getter
     private String email;
 
     @Enumerated(EnumType.STRING)
@@ -62,10 +56,8 @@ public class Mentee extends BaseEntity {
     }
 
     @Builder
-    public Mentee(Long id, String oauthUsername, String password, String email, Provider provider, String imageUrl, RequiredInfo requiredInfo, String refreshToken, Set<MenteePosition> interestedPositions, Set<MenteeField> interestedFields, String introduce) {
+    public Mentee(Long id,String email, Provider provider, String imageUrl, RequiredInfo requiredInfo, String refreshToken, Set<MenteePosition> interestedPositions, Set<MenteeField> interestedFields, String introduce) {
         this.id = id;
-        this.oauthUsername = oauthUsername;
-        this.password = password;
         this.email = email;
         this.provider = provider;
         this.imageUrl = imageUrl;

--- a/src/main/java/org/devcourse/resumeme/domain/mentee/RequiredInfo.java
+++ b/src/main/java/org/devcourse/resumeme/domain/mentee/RequiredInfo.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.devcourse.resumeme.domain.user.Role;
@@ -16,7 +17,7 @@ import static org.devcourse.resumeme.domain.user.Role.ROLE_PENDING;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RequiredInfo {
 
-    private static final String PHONE_REGEX = "^01(?:0|1|[6-9])(\\\\d{3}|\\\\d{4})(\\\\d{4})$";
+    private static final String PHONE_REGEX = "^01(0|1|[6-9])[0-9]{3,4}[0-9]{4}$";
 
     private String nickname;
 
@@ -28,10 +29,11 @@ public class RequiredInfo {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    public RequiredInfo(String nickname, String realName, String phoneNumber, Role role) {
+    @Builder
+    public RequiredInfo(String realName, String nickname, String phoneNumber, Role role) {
         validateRequiredInfo(nickname, realName, phoneNumber, role);
-        this.nickname = nickname;
         this.realName = realName;
+        this.nickname = nickname;
         this.phoneNumber = phoneNumber;
         this.role = role;
     }

--- a/src/main/java/org/devcourse/resumeme/domain/mentor/Mentor.java
+++ b/src/main/java/org/devcourse/resumeme/domain/mentor/Mentor.java
@@ -11,6 +11,7 @@ import jakarta.persistence.OneToMany;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.devcourse.resumeme.common.domain.BaseEntity;
 import org.devcourse.resumeme.domain.mentee.MenteePosition;
 import org.devcourse.resumeme.domain.mentee.RequiredInfo;
 import org.devcourse.resumeme.domain.user.Provider;
@@ -20,7 +21,7 @@ import java.util.Set;
 
 @Entity
 @NoArgsConstructor
-public class Mentor {
+public class Mentor extends BaseEntity {
 
     @Id
     @Getter
@@ -30,12 +31,6 @@ public class Mentor {
 
     @Getter
     @Column(unique = true)
-    private String oauthUsername;
-
-    @Getter
-    private String password;
-
-    @Getter
     private String email;
 
     @Enumerated(EnumType.STRING)
@@ -59,10 +54,8 @@ public class Mentor {
     private String introduce;
 
     @Builder
-    public Mentor(Long id, String oauthUsername, String password, String email, Provider provider, String imageUrl, RequiredInfo requiredInfo, String refreshToken, Set<MenteePosition> interestedPositions, String careerContent, int careerYear, String introduce) {
+    public Mentor(Long id, String email, Provider provider, String imageUrl, RequiredInfo requiredInfo, String refreshToken, Set<MenteePosition> interestedPositions, String careerContent, int careerYear, String introduce) {
         this.id = id;
-        this.oauthUsername = oauthUsername;
-        this.password = password;
         this.email = email;
         this.provider = provider;
         this.imageUrl = imageUrl;

--- a/src/main/java/org/devcourse/resumeme/domain/user/Provider.java
+++ b/src/main/java/org/devcourse/resumeme/domain/user/Provider.java
@@ -1,6 +1,9 @@
 package org.devcourse.resumeme.domain.user;
 
 import org.devcourse.resumeme.common.domain.DocsEnumType;
+import org.devcourse.resumeme.global.advice.exception.CustomException;
+
+import java.util.Arrays;
 
 public enum Provider implements DocsEnumType {
     KAKAO("kakao"),
@@ -10,6 +13,13 @@ public enum Provider implements DocsEnumType {
 
     Provider(String providerName) {
         this.providerName = providerName;
+    }
+
+    public static Provider of(String providerName) {
+        return Arrays.stream(values())
+                .filter(provider -> provider.providerName.equals(providerName))
+                .findAny()
+                .orElseThrow(() -> new CustomException("NOT_SUPPORTED_PROVIDER", "지원되지 않는 소셜로그인 입니다."));
     }
 
     @Override

--- a/src/main/java/org/devcourse/resumeme/domain/user/UserCommonInfo.java
+++ b/src/main/java/org/devcourse/resumeme/domain/user/UserCommonInfo.java
@@ -1,0 +1,16 @@
+package org.devcourse.resumeme.domain.user;
+
+import org.devcourse.resumeme.domain.mentee.Mentee;
+import org.devcourse.resumeme.domain.mentor.Mentor;
+
+public record UserCommonInfo(Long id, String email, Role role) {
+
+    public static UserCommonInfo of(Mentor mentor) {
+        return new UserCommonInfo(mentor.getId(), mentor.getEmail(), mentor.getRequiredInfo().getRole());
+    }
+
+    public static UserCommonInfo of(Mentee mentee) {
+        return new UserCommonInfo(mentee.getId(), mentee.getEmail(), mentee.getRequiredInfo().getRole());
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/global/auth/OAuth2CustomUser.java
+++ b/src/main/java/org/devcourse/resumeme/global/auth/OAuth2CustomUser.java
@@ -2,7 +2,7 @@ package org.devcourse.resumeme.global.auth;
 
 import lombok.Data;
 import lombok.Getter;
-import org.devcourse.resumeme.domain.user.User;
+import org.devcourse.resumeme.domain.user.UserCommonInfo;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -12,14 +12,14 @@ import java.util.List;
 import java.util.Map;
 
 @Data
-public class OAuth2CustomUser implements UserDetails, OAuth2User {
+public class OAuth2CustomUser implements OAuth2User {
 
     @Getter
-    private User user;
+    private UserCommonInfo userCommonInfo;
     private Map<String, Object> attributes;
 
-    public OAuth2CustomUser(User user, Map<String, Object> attributes) {
-        this.user = user;
+    public OAuth2CustomUser(UserCommonInfo userCommonInfo, Map<String, Object> attributes) {
+        this.userCommonInfo = userCommonInfo;
         this.attributes = attributes;
     }
 
@@ -35,37 +35,7 @@ public class OAuth2CustomUser implements UserDetails, OAuth2User {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(() -> String.valueOf(user.getRole()));
-    }
-
-    @Override
-    public String getPassword() {
-        return user.getPassword();
-    }
-
-    @Override
-    public String getUsername() {
-        return user.getOauthUsername();
-    }
-
-    @Override
-    public boolean isAccountNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isAccountNonLocked() {
-        return true;
-    }
-
-    @Override
-    public boolean isCredentialsNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return true;
+        return List.of(() -> String.valueOf(userCommonInfo.role()));
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/global/auth/OAuth2CustomUserService.java
+++ b/src/main/java/org/devcourse/resumeme/global/auth/OAuth2CustomUserService.java
@@ -1,62 +1,77 @@
 package org.devcourse.resumeme.global.auth;
 
 import lombok.RequiredArgsConstructor;
-import org.devcourse.resumeme.domain.user.Provider;
-import org.devcourse.resumeme.domain.user.Role;
-import org.devcourse.resumeme.domain.user.User;
+import lombok.extern.slf4j.Slf4j;
+import org.devcourse.resumeme.domain.mentee.Mentee;
+import org.devcourse.resumeme.domain.mentor.Mentor;
+import org.devcourse.resumeme.domain.user.UserCommonInfo;
+import org.devcourse.resumeme.global.advice.exception.CustomException;
+import org.devcourse.resumeme.global.auth.model.OAuth2TempInfo;
 import org.devcourse.resumeme.global.auth.userInfo.GoogleOAuth2UserInfo;
 import org.devcourse.resumeme.global.auth.userInfo.KakaoOAuth2UserInfo;
 import org.devcourse.resumeme.global.auth.userInfo.OAuth2UserInfo;
-import org.devcourse.resumeme.repository.UserRepository;
+import org.devcourse.resumeme.repository.MenteeRepository;
+import org.devcourse.resumeme.repository.MentorRepository;
+import org.devcourse.resumeme.repository.OAuth2TempInfoRepository;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
+import static org.devcourse.resumeme.domain.user.Provider.GOOGLE;
+import static org.devcourse.resumeme.domain.user.Provider.KAKAO;
+
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class OAuth2CustomUserService extends DefaultOAuth2UserService {
 
-    private final UserRepository userRepository;
+    private final MentorRepository mentorRepository;
+
+    private final MenteeRepository menteeRepository;
+
+    private final OAuth2TempInfoRepository oAuth2TempInfoRepository;
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
         String provider = userRequest.getClientRegistration().getRegistrationId();
-        Provider socialType = Provider.valueOf(provider.toUpperCase());
         OAuth2UserInfo userInfo = null;
 
-        if (provider.equals("google")) {
+        if (provider.equals(GOOGLE.getDescription())) {
             userInfo = new GoogleOAuth2UserInfo(oAuth2User.getAttributes());
         }
 
-        if (provider.equals("kakao")) {
+        if (provider.equals(KAKAO.getDescription())) {
             userInfo = new KakaoOAuth2UserInfo(oAuth2User.getAttributes());
         }
 
         if (userInfo == null) {
-            throw new RuntimeException("지원하지 않는 소셜로그인");
+            throw new CustomException("NOT_SUPPORTED_SOCIAL", "지원하지 않는 소셜로그인 입니다.");
         }
 
-        String oauthUsername = provider + "_" + userInfo.getId();
+        String email = userInfo.getEmail();
 
-        User userEntity;
-        OAuth2UserInfo finalUserInfo = userInfo;
+        Optional<Mentor> findMentor = mentorRepository.findByEmail(email);
+        Optional<Mentee> findMentee = menteeRepository.findByEmail(email);
 
-        userEntity = userRepository.findByOauthUsername(oauthUsername)
-                .orElseGet(() -> userRepository.save(
-                        User.builder().oauthUsername(oauthUsername)
-                                .imageUrl(finalUserInfo.getImageUrl())
-                                .role(Role.ROLE_MENTEE)
-                                .password("resumeme")
-                                .nickname(finalUserInfo.getNickname())
-                                .email(finalUserInfo.getEmail())
-                                .provider(socialType)
-                                .build()));
+        if (findMentor.isEmpty() && findMentee.isEmpty()) {
 
-        return new OAuth2CustomUser(userEntity, oAuth2User.getAttributes());
+            OAuth2TempInfo oAuth2TempInfo = new OAuth2TempInfo(userInfo.getId(), userInfo.getProvider(), userInfo.getNickname(), userInfo.getEmail(), userInfo.getImageUrl());
+            String cacheKey = oAuth2TempInfoRepository.save(oAuth2TempInfo).getId();
+            log.info("Redis Temporarily saved key : {}", cacheKey);
+
+            throw new OAuth2AuthenticationException(new OAuth2Error("NOT_REGISTERED"), cacheKey);
+        }
+
+        UserCommonInfo userCommonInfo = findMentor.map(UserCommonInfo::of).orElseGet(() -> UserCommonInfo.of(findMentee.get()));
+
+        return new OAuth2CustomUser(userCommonInfo, oAuth2User.getAttributes());
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/global/auth/OAuth2FailureHandler.java
+++ b/src/main/java/org/devcourse/resumeme/global/auth/OAuth2FailureHandler.java
@@ -1,0 +1,30 @@
+package org.devcourse.resumeme.global.auth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2FailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        String cacheKey = exception.getMessage();
+
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.addHeader("cacheKey", cacheKey);
+        response.addHeader("location", "/api/v1/user-info-form");
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/global/auth/OAuth2SuccessHandler.java
+++ b/src/main/java/org/devcourse/resumeme/global/auth/OAuth2SuccessHandler.java
@@ -3,9 +3,14 @@ package org.devcourse.resumeme.global.auth;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.devcourse.resumeme.domain.user.Role;
+import org.devcourse.resumeme.domain.user.UserCommonInfo;
 import org.devcourse.resumeme.global.advice.exception.CustomException;
+import org.devcourse.resumeme.global.auth.model.Claims;
+import org.devcourse.resumeme.global.auth.token.JwtService;
 import org.devcourse.resumeme.service.MenteeService;
 import org.devcourse.resumeme.service.MentorService;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -14,6 +19,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
+    private final JwtService jwtService;
+
     private final MentorService mentorService;
 
     private final MenteeService menteeService;
@@ -21,8 +28,23 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
         try {
+            OAuth2CustomUser oAuth2CustomUser = (OAuth2CustomUser) authentication.getPrincipal();
+            UserCommonInfo commonInfo = oAuth2CustomUser.getUserCommonInfo();
+            String accessToken = jwtService.createAccessToken(Claims.of(commonInfo));
+            String refreshToken = jwtService.createRefreshToken();
+
+            if (commonInfo.role().equals(Role.ROLE_MENTEE)) {
+                menteeService.updateRefreshToken(commonInfo.id(), refreshToken);
+            } else {
+                mentorService.updateRefreshToken(commonInfo.id(), refreshToken);
+            }
+
+            response.setCharacterEncoding("UTF-8");
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken);
+
         } catch (Exception e) {
-            throw new CustomException("FAIL_OAUTH_LOGIN", "소셜 로그인에 실패했습니다.");
+            throw new CustomException("FAIL_OAUTH_LOGIN", "로그인에 실패했습니다.");
         }
     }
 

--- a/src/main/java/org/devcourse/resumeme/global/auth/model/Claims.java
+++ b/src/main/java/org/devcourse/resumeme/global/auth/model/Claims.java
@@ -1,0 +1,12 @@
+package org.devcourse.resumeme.global.auth.model;
+
+import org.devcourse.resumeme.domain.user.UserCommonInfo;
+import java.util.Date;
+
+public record Claims(Long id, String role, Date expiration) {
+
+    public static Claims of(UserCommonInfo info) {
+        return new Claims(info.id(), info.role().toString(), new Date());
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/global/auth/model/OAuth2TempInfo.java
+++ b/src/main/java/org/devcourse/resumeme/global/auth/model/OAuth2TempInfo.java
@@ -1,0 +1,24 @@
+package org.devcourse.resumeme.global.auth.model;
+
+import lombok.Getter;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@RedisHash(value = "userInfo", timeToLive = 300)
+public class OAuth2TempInfo {
+
+    private final String id;
+    private final String provider;
+    private final String nickname;
+    private final String email;
+    private final String imageUrl;
+
+    public OAuth2TempInfo(String id, String provider, String nickname, String email, String imageUrl) {
+        this.id = id;
+        this.provider = provider;
+        this.nickname = nickname;
+        this.email = email;
+        this.imageUrl = imageUrl;
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/global/auth/token/JwtService.java
+++ b/src/main/java/org/devcourse/resumeme/global/auth/token/JwtService.java
@@ -1,0 +1,86 @@
+package org.devcourse.resumeme.global.auth.token;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.devcourse.resumeme.global.auth.model.Claims;
+import org.devcourse.resumeme.repository.MenteeRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+
+    private final MenteeRepository menteeRepository;
+
+    private static final String ACCESS_TOKEN_NAME = "access";
+
+    private static final String REFRESH_TOKEN_NAME = "refresh";
+
+    private static final int ACCESS_TOKEN_EXP = 3600 * 1000;
+
+    private static final int REFRESH_TOKEN_EXP = 3600 * 24 * 7 * 1000;
+
+    private static final String ID = "id";
+
+    private static final String ROLE = "role";
+
+    private static final String BEARER = "Bearer ";
+
+    private static final String SECRET_KEY = "resumeJWT";
+
+    public String createAccessToken(Claims claims) {
+        return JWT.create()
+                .withSubject(ACCESS_TOKEN_NAME)
+                .withExpiresAt(new Date(claims.expiration().getTime() + ACCESS_TOKEN_EXP))
+                .withClaim(ID, claims.id())
+                .withClaim(ROLE, claims.role())
+                .sign(Algorithm.HMAC512(SECRET_KEY));
+
+    }
+
+    public String createRefreshToken() {
+        Date now = new Date();
+        return JWT.create()
+                .withSubject(REFRESH_TOKEN_NAME)
+                .withExpiresAt(new Date(now.getTime() + REFRESH_TOKEN_EXP))
+                .sign(Algorithm.HMAC512(SECRET_KEY));
+    }
+
+    public void sendAccessToken(HttpServletResponse response, String accessToken) {
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setHeader(ACCESS_TOKEN_NAME, accessToken);
+    }
+
+    public void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken) {
+        response.setStatus(HttpServletResponse.SC_OK);
+        setAccessTokenHeader(response, accessToken);
+        setRefreshTokenHeader(response, refreshToken);
+    }
+
+    public Optional<String> extractRefreshToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(REFRESH_TOKEN_NAME))
+                .filter(refreshToken -> refreshToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+    public Optional<String> extractAccessToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(ACCESS_TOKEN_NAME))
+                .filter(refreshToken -> refreshToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+    public void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
+        response.setHeader(ACCESS_TOKEN_NAME, accessToken);
+    }
+
+    public void setRefreshTokenHeader(HttpServletResponse response, String refreshToken) {
+        response.setHeader(REFRESH_TOKEN_NAME, refreshToken);
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/global/auth/userInfo/GoogleOAuth2UserInfo.java
+++ b/src/main/java/org/devcourse/resumeme/global/auth/userInfo/GoogleOAuth2UserInfo.java
@@ -14,6 +14,11 @@ public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
     }
 
     @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    @Override
     public String getNickname() {
         return attributes.get("name").toString();
     }

--- a/src/main/java/org/devcourse/resumeme/global/auth/userInfo/KakaoOAuth2UserInfo.java
+++ b/src/main/java/org/devcourse/resumeme/global/auth/userInfo/KakaoOAuth2UserInfo.java
@@ -14,6 +14,11 @@ public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
     }
 
     @Override
+    public String getProvider() {
+        return "kakao";
+    }
+
+    @Override
     public String getNickname() {
         Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
         Map<String, Object> profile = (Map<String, Object>) account.get("profile");

--- a/src/main/java/org/devcourse/resumeme/global/auth/userInfo/OAuth2UserInfo.java
+++ b/src/main/java/org/devcourse/resumeme/global/auth/userInfo/OAuth2UserInfo.java
@@ -12,6 +12,8 @@ public abstract class OAuth2UserInfo {
 
     public abstract String getId();
 
+    public abstract String getProvider();
+
     public abstract String getNickname();
 
     public abstract String getEmail();

--- a/src/main/java/org/devcourse/resumeme/global/config/RedisRepositoryConfig.java
+++ b/src/main/java/org/devcourse/resumeme/global/config/RedisRepositoryConfig.java
@@ -1,0 +1,25 @@
+package org.devcourse.resumeme.global.config;
+
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisRepositoryConfig {
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(RedisProperties properties) {
+        return new LettuceConnectionFactory(properties.getHost(), properties.getPort());
+    }
+
+    @Bean
+    public StringRedisTemplate redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        return new StringRedisTemplate(redisConnectionFactory);
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/global/config/SecurityConfig.java
+++ b/src/main/java/org/devcourse/resumeme/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package org.devcourse.resumeme.global.config;
 
 import lombok.RequiredArgsConstructor;
 import org.devcourse.resumeme.global.auth.OAuth2CustomUserService;
+import org.devcourse.resumeme.global.auth.OAuth2FailureHandler;
 import org.devcourse.resumeme.global.auth.OAuth2SuccessHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,6 +24,8 @@ public class SecurityConfig {
 
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
+    private final OAuth2FailureHandler oAuth2FailureHandler;
+
     private final OAuth2CustomUserService oAuth2CustomUserService;
 
     @Bean
@@ -35,7 +38,8 @@ public class SecurityConfig {
                 .oauth2Login(configure ->
                         configure.userInfoEndpoint(userConfig ->
                                         userConfig.userService(oAuth2CustomUserService))
-                                .successHandler(oAuth2SuccessHandler));
+                                .successHandler(oAuth2SuccessHandler)
+                                .failureHandler(oAuth2FailureHandler));
 
         return http.build();
     }

--- a/src/main/java/org/devcourse/resumeme/repository/MenteeRepository.java
+++ b/src/main/java/org/devcourse/resumeme/repository/MenteeRepository.java
@@ -7,6 +7,6 @@ import java.util.Optional;
 
 public interface MenteeRepository extends JpaRepository<Mentee, Long> {
 
-    Optional<Mentee> findMenteeByOauthUsername(String oauthUsername);
+    Optional<Mentee> findByEmail(String email);
 
 }

--- a/src/main/java/org/devcourse/resumeme/repository/MentorRepository.java
+++ b/src/main/java/org/devcourse/resumeme/repository/MentorRepository.java
@@ -7,6 +7,6 @@ import java.util.Optional;
 
 public interface MentorRepository extends JpaRepository<Mentor, Long> {
 
-    Optional<Mentor> findMentorByOauthUsername(String oauthUsername);
+    Optional<Mentor> findByEmail(String email);
 
 }

--- a/src/main/java/org/devcourse/resumeme/repository/OAuth2TempInfoRepository.java
+++ b/src/main/java/org/devcourse/resumeme/repository/OAuth2TempInfoRepository.java
@@ -1,0 +1,8 @@
+package org.devcourse.resumeme.repository;
+
+import org.devcourse.resumeme.global.auth.model.OAuth2TempInfo;
+import org.springframework.data.repository.CrudRepository;
+
+public interface OAuth2TempInfoRepository extends CrudRepository<OAuth2TempInfo, String> {
+
+}

--- a/src/main/java/org/devcourse/resumeme/service/MenteeService.java
+++ b/src/main/java/org/devcourse/resumeme/service/MenteeService.java
@@ -8,17 +8,21 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class MenteeService {
 
     private final MenteeRepository menteeRepository;
+
+    public Mentee create(Mentee mentee) {
+        return menteeRepository.save(mentee);
+    }
 
     @Transactional(readOnly = true)
     public Mentee getOne(Long id) {
         return menteeRepository.findById(id).orElseThrow(() -> new CustomException("MENTEE_NOT_FOUND", "존재하지 않는 회원입니다."));
     }
 
-    @Transactional
     public void updateRefreshToken(Long id, String refreshToken) {
         Mentee findMentee = getOne(id);
         findMentee.updateRefreshToken(refreshToken);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,10 @@ spring:
     open-in-view: false
   config:
     import: application-endpoint.yml, application-auth.yml
+  data:
+    redis:
+      host: localhost
+      port: 6379
 ---
 spring:
   config:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: test


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
- 소셜 회원가입 이력 존재 회원 
: access token, refresh token 발급 후 헤더에 넣어 반환
- 소셜 회원가입 이력 부재 회원 
: 소셜에서 얻은 회원정보 redis에 저장 후 추가 정보 입력 받아서 회원 db (멘토, 멘티) 에 최종 저장. 
access token, refresh token 발급 후 헤더에 넣어 반환

## CC. 리뷰어
혹시 누락된 부분이 있는지 꼼꼼히 봐주시면 감사하겠습니다!!

## 테스트 설명


## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
