### PR TITLE
feat: 이벤트 신청 시 이력서 복사

### DIFF
--- a/src/main/java/org/devcourse/resumeme/controller/EventController.java
+++ b/src/main/java/org/devcourse/resumeme/controller/EventController.java
@@ -33,9 +33,9 @@ public class EventController {
     private final MentorService mentorService;
 
     @PostMapping
-    public IdResponse createEvent(@RequestBody EventCreateRequest request /* @AuthenticationPrincipal 인증 유저 */) {
+    public IdResponse createEvent(@RequestBody EventCreateRequest request, @AuthenticationPrincipal JwtUser user) {
         /* 인증 유저 아이디를 통한 멘토 찾아오기 */
-        Mentor mentor = new Mentor();
+        Mentor mentor = mentorService.getOne(user.id());
         Event event = request.toEntity(mentor);
 
         return new IdResponse(eventService.create(event));

--- a/src/main/java/org/devcourse/resumeme/domain/resume/Resume.java
+++ b/src/main/java/org/devcourse/resumeme/domain/resume/Resume.java
@@ -100,8 +100,8 @@ public class Resume extends BaseEntity {
 
     public Resume copy() {
         return new Resume(
-                null, title, mentee,position, introduce,
-                career,project, certification, activity, foreignLanguage,
+                null, title, mentee, position, introduce,
+                career, project, certification, activity, foreignLanguage,
                 email, githubAddress, blogAddress, phoneNumber
         );
     }

--- a/src/main/java/org/devcourse/resumeme/domain/resume/Resume.java
+++ b/src/main/java/org/devcourse/resumeme/domain/resume/Resume.java
@@ -16,8 +16,6 @@ import lombok.NoArgsConstructor;
 import org.devcourse.resumeme.common.domain.BaseEntity;
 import org.devcourse.resumeme.common.domain.Position;
 import org.devcourse.resumeme.domain.mentee.Mentee;
-import org.devcourse.resumeme.domain.user.User;
-import org.devcourse.resumeme.global.advice.exception.CustomException;
 import org.devcourse.resumeme.global.advice.exception.ExceptionCode;
 
 import static org.devcourse.resumeme.common.util.Validator.validate;
@@ -81,6 +79,31 @@ public class Resume extends BaseEntity {
     private static void validateResume(String title, Mentee mentee) {
         validate(title == null, ExceptionCode.NO_EMPTY_VALUE);
         validate(mentee == null, ExceptionCode.MENTEE_NOT_FOUND);
+    }
+
+    private Resume(Long id, String title, Mentee mentee, Position position, String introduce, Career career, Project project, Certification certification, Activity activity, ForeignLanguage foreignLanguage, String email, String githubAddress, String blogAddress, String phoneNumber) {
+        this.id = id;
+        this.title = title;
+        this.mentee = mentee;
+        this.position = position;
+        this.introduce = introduce;
+        this.career = career;
+        this.project = project;
+        this.certification = certification;
+        this.activity = activity;
+        this.foreignLanguage = foreignLanguage;
+        this.email = email;
+        this.githubAddress = githubAddress;
+        this.blogAddress = blogAddress;
+        this.phoneNumber = phoneNumber;
+    }
+
+    public Resume copy() {
+        return new Resume(
+                null, title, mentee,position, introduce,
+                career,project, certification, activity, foreignLanguage,
+                email, githubAddress, blogAddress, phoneNumber
+        );
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/global/advice/exception/ExceptionCode.java
+++ b/src/main/java/org/devcourse/resumeme/global/advice/exception/ExceptionCode.java
@@ -2,6 +2,7 @@ package org.devcourse.resumeme.global.advice.exception;
 
 public enum ExceptionCode {
     MENTEE_NOT_FOUND("해당 멘티를 찾을 수 없습니다."),
+    RESUME_NOT_FOUND("해당 이력서를 찾을 수 없습니다."),
     NO_EMPTY_VALUE("빈 값일 수 없습니다"),
     MENTEE_ONLY_RESUME("멘티만 이력서를 작성할 수 있습니다.");
 

--- a/src/main/java/org/devcourse/resumeme/service/ResumeService.java
+++ b/src/main/java/org/devcourse/resumeme/service/ResumeService.java
@@ -1,10 +1,13 @@
 package org.devcourse.resumeme.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.devcourse.resumeme.domain.resume.Resume;
+import org.devcourse.resumeme.global.advice.exception.CustomException;
 import org.devcourse.resumeme.repository.ResumeRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.devcourse.resumeme.global.advice.exception.ExceptionCode.RESUME_NOT_FOUND;
 
 @Service
 @Transactional
@@ -17,6 +20,16 @@ public class ResumeService {
         Resume saved = resumeRepository.save(resume);
 
         return saved.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public Resume getOne(Long id) {
+        return resumeRepository.findById(id)
+                .orElseThrow(() -> new CustomException(RESUME_NOT_FOUND));
+    }
+
+    public Long copyResume(Long id) {
+        return create(getOne(id).copy());
     }
 
 }

--- a/src/test/java/org/devcourse/resumeme/common/ControllerUnitTest.java
+++ b/src/test/java/org/devcourse/resumeme/common/ControllerUnitTest.java
@@ -6,6 +6,7 @@ import org.devcourse.resumeme.common.controller.EnumController;
 import org.devcourse.resumeme.controller.EventController;
 import org.devcourse.resumeme.controller.ResumeController;
 import org.devcourse.resumeme.service.EventService;
+import org.devcourse.resumeme.service.MentorService;
 import org.devcourse.resumeme.service.ResumeService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -38,6 +39,9 @@ public abstract class ControllerUnitTest {
 
     @MockBean
     protected ResumeService resumeService;
+
+    @MockBean
+    protected MentorService mentorService;
 
     protected MockMvc mvc;
 

--- a/src/test/java/org/devcourse/resumeme/controller/EventControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/controller/EventControllerTest.java
@@ -12,6 +12,7 @@ import org.devcourse.resumeme.domain.event.EventTimeInfo;
 import org.devcourse.resumeme.domain.mentor.Mentor;
 import org.devcourse.resumeme.service.vo.AcceptMenteeToEvent;
 import org.devcourse.resumeme.service.vo.EventReject;
+import org.devcourse.resumeme.support.WithMockCustomUser;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
@@ -41,6 +42,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class EventControllerTest extends ControllerUnitTest {
 
     @Test
+    @WithMockCustomUser
     void 첨삭_이벤트_생성에_성공한다() throws Exception {
         // given
         EventInfoRequest eventInfoRequest = new EventInfoRequest("title", "content", 3);
@@ -52,9 +54,11 @@ class EventControllerTest extends ControllerUnitTest {
         );
         EventCreateRequest eventCreateRequest = new EventCreateRequest(eventInfoRequest, eventTimeRequest, List.of("FRONT", "BACK"));
         /* 로그인 기능 완료 후 멘토 주입 값 추후 변경 예정 */
-        Event event = eventCreateRequest.toEntity(new Mentor());
+        Mentor mentor = new Mentor();
+        Event event = eventCreateRequest.toEntity(mentor);
 
         given(eventService.create(event)).willReturn(1L);
+        given(mentorService.getOne(1L)).willReturn(mentor);
 
         // when
         ResultActions result = mvc.perform(post("/api/v1/events")
@@ -86,6 +90,7 @@ class EventControllerTest extends ControllerUnitTest {
     }
 
     @Test
+    @WithMockCustomUser
     void 첨삭_이벤트_참여에_성공한다() throws Exception {
         // given
         EventInfo openEvent = EventInfo.open(3, "제목", "내용");

--- a/src/test/java/org/devcourse/resumeme/support/WithMockCustomUser.java
+++ b/src/test/java/org/devcourse/resumeme/support/WithMockCustomUser.java
@@ -1,0 +1,14 @@
+package org.devcourse.resumeme.support;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+
+    String id() default "1";
+
+}

--- a/src/test/java/org/devcourse/resumeme/support/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/org/devcourse/resumeme/support/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,21 @@
+package org.devcourse.resumeme.support;
+
+import org.devcourse.resumeme.global.auth.model.JwtUser;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.List;
+
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
+        SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+        securityContext.setAuthentication(new UsernamePasswordAuthenticationToken(new JwtUser(Long.parseLong(annotation.id())), null, List.of(() -> "ROLE_USER")));
+
+        return securityContext;
+    }
+
+}


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
이벤트 신청 시 이력서 복사해서 저장하도록 기능 추가했습니다

## CC. 리뷰어


## 테스트 설명
- WithMockCustomUser : AuthenticationPrincipal을 사용하는 컨트롤러 테스트 시 사용하면 됩니다
- EventControllerTest : JwtUser 추가로 인한 수정, Resume, MentorService given절 추가
## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
