### PR TITLE
feat: 이벤트 리뷰 도메인 도출

### DIFF
--- a/src/main/java/org/devcourse/resumeme/domain/resume/BlockType.java
+++ b/src/main/java/org/devcourse/resumeme/domain/resume/BlockType.java
@@ -1,0 +1,14 @@
+package org.devcourse.resumeme.domain.resume;
+
+public enum BlockType {
+
+    ACTIVITY,
+    CAREER,
+    CERTIFICATION,
+    DUTY,
+    FOREIGN_LANGUAGE,
+    PROJECT,
+    SKILL,
+    TRAINING;
+
+}

--- a/src/main/java/org/devcourse/resumeme/domain/review/Review.java
+++ b/src/main/java/org/devcourse/resumeme/domain/review/Review.java
@@ -1,0 +1,51 @@
+package org.devcourse.resumeme.domain.review;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.NoArgsConstructor;
+import org.devcourse.resumeme.common.domain.BaseEntity;
+import org.devcourse.resumeme.domain.resume.BlockType;
+import org.devcourse.resumeme.domain.resume.Resume;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+import static org.devcourse.resumeme.common.util.Validator.Condition.isBlank;
+import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.global.advice.exception.ExceptionCode.NO_EMPTY_VALUE;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "review_id")
+    private Long id;
+
+    private String content;
+
+    @Enumerated(STRING)
+    private BlockType type;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "resume_id")
+    private Resume resume;
+
+    public Review(String content, BlockType type, Resume resume) {
+        validate(isBlank(content), NO_EMPTY_VALUE);
+        validate(type == null, NO_EMPTY_VALUE);
+        validate(resume == null, NO_EMPTY_VALUE);
+
+        this.content = content;
+        this.type = type;
+        this.resume = resume;
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/repository/ReviewRepository.java
+++ b/src/main/java/org/devcourse/resumeme/repository/ReviewRepository.java
@@ -1,0 +1,8 @@
+package org.devcourse.resumeme.repository;
+
+import org.devcourse.resumeme.domain.review.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+}

--- a/src/test/java/org/devcourse/resumeme/domain/review/ReviewTest.java
+++ b/src/test/java/org/devcourse/resumeme/domain/review/ReviewTest.java
@@ -1,0 +1,69 @@
+package org.devcourse.resumeme.domain.review;
+
+import org.devcourse.resumeme.common.domain.Position;
+import org.devcourse.resumeme.domain.event.Event;
+import org.devcourse.resumeme.domain.event.EventInfo;
+import org.devcourse.resumeme.domain.event.EventPosition;
+import org.devcourse.resumeme.domain.event.EventTimeInfo;
+import org.devcourse.resumeme.domain.mentee.Mentee;
+import org.devcourse.resumeme.domain.mentor.Mentor;
+import org.devcourse.resumeme.domain.resume.BlockType;
+import org.devcourse.resumeme.domain.resume.Resume;
+import org.devcourse.resumeme.global.advice.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ReviewTest {
+
+    @Test
+    void 리뷰_작성에_성공한다() {
+        // given
+        String content = "내용 수정해주세요";
+        BlockType type = BlockType.CAREER;
+        Resume resume = new Resume("title", Mentee.builder().build());
+
+        // when
+        Review review = new Review(content, type, resume);
+
+        // then
+        assertThat(review).isNotNull();
+    }
+
+    @ParameterizedTest
+    @MethodSource("reviewCreate")
+    void 이벤트포지션_생성_검증조건_미달로인해_생성에_실패한다_null입력_오류(String content, BlockType type, Resume resume) {
+        // then
+        assertThatThrownBy(() -> new Review(content, type, resume))
+                .isInstanceOf(CustomException.class);
+    }
+
+    static Stream<Arguments> reviewCreate() {
+        String content = "내용 수정해주세요";
+        BlockType type = BlockType.CAREER;
+        Resume resume = new Resume("title", Mentee.builder().build());
+
+        return Stream.of(
+                Arguments.of(null, null, null),
+                Arguments.of(content, null, null),
+                Arguments.of(null, type, null),
+                Arguments.of(null, null, resume),
+                Arguments.of("", type, null),
+                Arguments.of("   ", null, resume)
+        );
+    }
+
+}


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
이벤트 리뷰 도메인 도출

## CC. 리뷰어
@beomukim 리뷰 작성 시 블락단위로 리뷰를 하다보니 어떤 블락인지를 나타내기 위해 BlockType이라는 enum 값을 생성했는데 [`@Transient`](https://gmoon92.github.io/jpa/2019/09/29/what-is-the-transient-annotation-used-for-in-jpa.html)를 각 블락 Entity에 작성해둬야 할 것 같은데 제가 추가해둬도 될까요? 이번 pr에 같이 추가해서 올려둘게요

따로 DB에 저장은 되지 않고 애플리케이션 단에서만 사용하게 됩니다

나중에 이력서 조회 시 해당 type을 프론트에 같이 전달 해 주실 수 있나요?

## 테스트 설명
- ReviewTest

## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
