### PR TITLE
feat: 첨삭 전 후 이력서 멘토 조회

### DIFF
--- a/src/main/java/org/devcourse/resumeme/controller/dto/EventResponse.java
+++ b/src/main/java/org/devcourse/resumeme/controller/dto/EventResponse.java
@@ -1,0 +1,41 @@
+package org.devcourse.resumeme.controller.dto;
+
+import org.devcourse.resumeme.domain.event.Event;
+import org.devcourse.resumeme.domain.event.MenteeToEvent;
+import org.devcourse.resumeme.domain.resume.Resume;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record EventResponse(EventInfoResponse info, List<ResumeResponse> resumes) {
+
+    public EventResponse(Event event, List<Resume> resumes) {
+        this(new EventInfoResponse(event), toResponse(event, resumes));
+    }
+
+    public static List<ResumeResponse> toResponse(Event event, List<Resume> resumes) {
+        return event.getApplicants().stream()
+                .flatMap(
+                        applicant -> resumes.stream()
+                                .filter(resume -> resume.getId().equals(applicant.getResumeId()))
+                                .map(resume -> new ResumeResponse(applicant, resume))
+                ).toList();
+    }
+
+    public record EventInfoResponse(String title, int maximumCount, LocalDateTime endDate) {
+
+        public EventInfoResponse(Event event) {
+            this(event.title(), event.maximumCount(), event.endDate());
+        }
+
+    }
+
+    public record ResumeResponse(Long resumeId, String menteeName, String resumeTitle, String progressStatus) {
+
+        public ResumeResponse(MenteeToEvent applicant, Resume resume) {
+            this(resume.getId(), resume.menteeName(), resume.getTitle(), applicant.getProgress().name());
+        }
+
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/domain/event/Event.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/Event.java
@@ -48,6 +48,7 @@ public class Event extends BaseEntity {
     @OneToMany(mappedBy = "event", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
     private List<EventPosition> positions = new ArrayList<>();
 
+    @Getter
     @OneToMany(mappedBy = "event", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
     private List<MenteeToEvent> applicants = new ArrayList<>();
 
@@ -140,6 +141,18 @@ public class Event extends BaseEntity {
                         MenteeToEvent::requestReview,
                         () -> {throw new EventException("MENTEE_NOT_FOUND", "참여중인 멘티가 없습니다");}
                 );
+    }
+
+    public String title() {
+        return eventInfo.getTitle();
+    }
+
+    public int maximumCount() {
+        return eventInfo.getMaximumAttendee();
+    }
+
+    public LocalDateTime endDate() {
+        return eventTimeInfo.getEndDate();
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventInfo.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventInfo.java
@@ -2,6 +2,7 @@ package org.devcourse.resumeme.domain.event;
 
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Enumerated;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.devcourse.resumeme.domain.event.exception.EventException;
 
@@ -14,8 +15,10 @@ import static org.devcourse.resumeme.common.util.Validator.validate;
 @NoArgsConstructor(access = PROTECTED)
 public class EventInfo {
 
+    @Getter
     private int maximumAttendee;
 
+    @Getter
     private String title;
 
     private String content;

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventTimeInfo.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventTimeInfo.java
@@ -1,6 +1,7 @@
 package org.devcourse.resumeme.domain.event;
 
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.devcourse.resumeme.domain.event.exception.EventException;
 
@@ -17,6 +18,7 @@ public class EventTimeInfo {
 
     private LocalDateTime closeDateTime;
 
+    @Getter
     private LocalDateTime endDate;
 
     private EventTimeInfo(LocalDateTime openDateTime, LocalDateTime closeDateTime, LocalDateTime endDate) {

--- a/src/main/java/org/devcourse/resumeme/domain/event/MenteeToEvent.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/MenteeToEvent.java
@@ -31,10 +31,13 @@ public class MenteeToEvent extends BaseEntity {
     @JoinColumn(name = "event_id")
     private Event event;
 
+    @Getter
     private Long menteeId;
 
+    @Getter
     private Long resumeId;
 
+    @Getter
     private Progress progress;
 
     private String rejectMessage;

--- a/src/main/java/org/devcourse/resumeme/domain/resume/Resume.java
+++ b/src/main/java/org/devcourse/resumeme/domain/resume/Resume.java
@@ -35,6 +35,7 @@ public class Resume extends BaseEntity {
     @Column(name = "resume_id")
     private Long id;
 
+    @Getter
     private String title;
 
     @ManyToOne
@@ -106,6 +107,14 @@ public class Resume extends BaseEntity {
                 career, project, certification, activity, foreignLanguage,
                 email, githubAddress, blogAddress, phoneNumber
         );
+    }
+
+    public Long menteeId() {
+        return this.mentee.getId();
+    }
+
+    public String menteeName() {
+        return this.mentee.getRequiredInfo().getNickname();
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/repository/EventRepository.java
+++ b/src/main/java/org/devcourse/resumeme/repository/EventRepository.java
@@ -3,6 +3,7 @@ package org.devcourse.resumeme.repository;
 import jakarta.persistence.LockModeType;
 import org.devcourse.resumeme.domain.event.Event;
 import org.devcourse.resumeme.domain.mentor.Mentor;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 
@@ -15,5 +16,8 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     Optional<Event> findWithLockById(Long id);
 
     List<Event> findAllByMentor(Mentor mentor);
+
+    @EntityGraph(attributePaths = {"applicants"})
+    Optional<Event> findWithApplicantsById(Long id);
 
 }

--- a/src/main/java/org/devcourse/resumeme/service/EventService.java
+++ b/src/main/java/org/devcourse/resumeme/service/EventService.java
@@ -50,7 +50,7 @@ public class EventService {
 
     @Transactional(readOnly = true)
     public Event getOne(Long eventId) {
-        return eventRepository.findById(eventId)
+        return eventRepository.findWithApplicantsById(eventId)
                 .orElseThrow(() -> new EventException("NOT_FOUND", "이벤트를 찾을 수 없습니다"));
     }
 

--- a/src/main/java/org/devcourse/resumeme/service/ResumeService.java
+++ b/src/main/java/org/devcourse/resumeme/service/ResumeService.java
@@ -7,6 +7,8 @@ import org.devcourse.resumeme.repository.ResumeRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static org.devcourse.resumeme.global.advice.exception.ExceptionCode.RESUME_NOT_FOUND;
 
 @Service
@@ -30,6 +32,10 @@ public class ResumeService {
 
     public Long copyResume(Long id) {
         return create(getOne(id).copy());
+    }
+
+    public List<Resume> getAll(List<Long> resumeIds) {
+        return resumeRepository.findAllById(resumeIds);
     }
 
 }

--- a/src/test/java/org/devcourse/resumeme/service/EventServiceTest.java
+++ b/src/test/java/org/devcourse/resumeme/service/EventServiceTest.java
@@ -147,13 +147,13 @@ class EventServiceTest {
         event.acceptMentee(1L, 1L);
 
         EventReject reject = new EventReject(1L, 1L, "이력서 양이 너무 적습니다");
-        lenient().when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+        lenient().when(eventRepository.findWithApplicantsById(1L)).thenReturn(Optional.of(event));
 
         // when
         eventService.reject(reject);
 
         // then
-        verify(eventRepository).findById(1L);
+        verify(eventRepository).findWithApplicantsById(1L);
     }
 
     @Test
@@ -165,7 +165,7 @@ class EventServiceTest {
         event.acceptMentee(1L, 1L);
 
         EventReject reject = new EventReject(1L, 2L, "이력서 양이 너무 적습니다");
-        given(eventRepository.findById(1L)).willReturn(Optional.of(event));
+        given(eventRepository.findWithApplicantsById(1L)).willReturn(Optional.of(event));
 
         // when & then
         assertThatThrownBy(() -> eventService.reject(reject)).isInstanceOf(EventException.class);


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
첨삭 전 후 이력서 멘토 조회
따로 상태에 맞게 나누는 것 보다는 이력서 반환 값에 첨삭 진행 상태에 대한 값으로 나타냈습니다
eventRepository에서 참여자 정보에 대해서 fetch join 추가했습니다

## CC. 리뷰어
수정된 도메인들은 게터 추가 입니다
(Event, EventInfo, EventTimeInfo, MenteeToEvent, Resume)
게터... 

## 테스트 설명
- EventServiceTest
- EventControllerTest

## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
