### PR TITLE
docs: 문서 role 별로 분리

### DIFF
--- a/src/docs/asciidoc/all.adoc
+++ b/src/docs/asciidoc/all.adoc
@@ -1,0 +1,19 @@
+= 모두
+=== 멘토 가입
+
+*Request*
+include::{snippets}/mentor/create/http-request.adoc[]
+include::{snippets}/mentor/create/request-fields.adoc[]
+
+*Response*
+include::{snippets}/mentor/create/http-response.adoc[]
+include::{snippets}/mentor/create/response-fields.adoc[]
+
+=== 멘티 가입
+*Request*
+include::{snippets}/mentee/create/http-request.adoc[]
+include::{snippets}/mentee/create/request-fields.adoc[]
+
+*Response*
+include::{snippets}/mentee/create/http-response.adoc[]
+include::{snippets}/mentee/create/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -17,69 +17,7 @@ endif::[]
 
 // filename은 src/test/java/o.d.r/common/DocumentLinkGenerator#DocUrl
 // 필드 중 htmlFileName과 동일한 이름을 주면 됩니다
-= 첨삭 이벤트
-== 생성
-=== Request
-include::{snippets}/event/create/http-request.adoc[]
-include::{snippets}/event/create/request-fields.adoc[]
 
-=== Response
-include::{snippets}/event/create/http-response.adoc[]
-include::{snippets}/event/create/response-fields.adoc[]
-
-== 신청
-=== Request
-include::{snippets}/event/apply/http-request.adoc[]
-include::{snippets}/event/apply/request-fields.adoc[]
-
-=== Response
-include::{snippets}/event/apply/http-response.adoc[]
-include::{snippets}/event/apply/response-fields.adoc[]
-
-== 반려
-=== Request
-include::{snippets}/event/reject/http-request.adoc[]
-include::{snippets}/event/reject/request-fields.adoc[]
-
-=== Response
-include::{snippets}/event/reject/http-response.adoc[]
-
-= 이력서
-== 생성
-=== Request
-include::{snippets}/resume/create/http-request.adoc[]
-include::{snippets}/resume/create/request-fields.adoc[]
-
-=== Response
-include::{snippets}/resume/create/http-response.adoc[]
-include::{snippets}/resume/create/response-fields.adoc[]
-
-= 멘토
-== 생성
-=== Request
-include::{snippets}/mentor/create/http-request.adoc[]
-include::{snippets}/mentor/create/request-fields.adoc[]
-
-=== Response
-include::{snippets}/mentor/create/http-response.adoc[]
-include::{snippets}/mentor/create/response-fields.adoc[]
-
-= 멘티
-== 생성
-=== Request
-include::{snippets}/mentee/create/http-request.adoc[]
-include::{snippets}/mentee/create/request-fields.adoc[]
-
-=== Response
-include::{snippets}/mentee/create/http-response.adoc[]
-include::{snippets}/mentee/create/response-fields.adoc[]
-
-= 리뷰
-== 생성
-=== Request
-include::{snippets}/review/create/http-request.adoc[]
-include::{snippets}/review/create/request-fields.adoc[]
-
-=== Response
-include::{snippets}/review/create/http-response.adoc[]
-include::{snippets}/review/create/response-fields.adoc[]
+include::mentor.adoc[]
+include::mentee.adoc[]
+include::all.adoc[]

--- a/src/docs/asciidoc/mentee.adoc
+++ b/src/docs/asciidoc/mentee.adoc
@@ -1,0 +1,29 @@
+= 멘티
+
+=== 첨삭 참여 신청
+
+*Request*
+include::{snippets}/event/apply/http-request.adoc[]
+include::{snippets}/event/apply/request-fields.adoc[]
+
+*Response*
+include::{snippets}/event/apply/http-response.adoc[]
+include::{snippets}/event/apply/response-fields.adoc[]
+
+=== 이력서 작성
+
+*Request*
+include::{snippets}/resume/create/http-request.adoc[]
+include::{snippets}/resume/create/request-fields.adoc[]
+
+*Response*
+include::{snippets}/resume/create/http-response.adoc[]
+include::{snippets}/resume/create/response-fields.adoc[]
+
+=== 리뷰 재요청
+
+*Request*
+include::{snippets}/event/requestReview/http-request.adoc[]
+
+*Response*
+include::{snippets}/event/requestReview/http-response.adoc[]

--- a/src/docs/asciidoc/mentor.adoc
+++ b/src/docs/asciidoc/mentor.adoc
@@ -1,0 +1,40 @@
+= 멘토
+
+=== 첨삭 이벤트 생성
+
+*Request*
+include::{snippets}/event/create/http-request.adoc[]
+include::{snippets}/event/create/request-fields.adoc[]
+
+*Response*
+include::{snippets}/event/create/http-response.adoc[]
+include::{snippets}/event/create/response-fields.adoc[]
+
+=== 참여 신청 반려
+
+*Request*
+include::{snippets}/event/reject/http-request.adoc[]
+include::{snippets}/event/reject/request-fields.adoc[]
+
+*Response*
+include::{snippets}/event/reject/http-response.adoc[]
+
+=== 특정 이벤트 관련 정보 보기
+
+*Request*
+include::{snippets}/event/getOwn/http-request.adoc[]
+include::{snippets}/event/getOwn/path-parameters.adoc[]
+
+*Response*
+include::{snippets}/event/getOwn/http-response.adoc[]
+include::{snippets}/event/getOwn/response-fields.adoc[]
+
+=== 첨삭 관련 리뷰 작성
+
+*Request*
+include::{snippets}/review/create/http-request.adoc[]
+include::{snippets}/review/create/request-fields.adoc[]
+
+*Response*
+include::{snippets}/review/create/http-response.adoc[]
+include::{snippets}/review/create/response-fields.adoc[]


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
rest docs 역할 별로 문서 분리
**이전**
![image](https://github.com/resumeme/Backend/assets/75611167/29d63206-de37-4262-a840-75c123925702)

**이후**
![image](https://github.com/resumeme/Backend/assets/75611167/2454c802-cdf2-4a95-9bfc-550a27681595)

## CC. 리뷰어
추후 all, mentor, mentee 별로 각각 파일에 작성하시면 됩니다

## 테스트 설명


## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
