### PR TITLE
feat: 어드민 도메인 구현

### DIFF
--- a/src/main/java/org/devcourse/resumeme/domain/admin/Admin.java
+++ b/src/main/java/org/devcourse/resumeme/domain/admin/Admin.java
@@ -1,0 +1,35 @@
+package org.devcourse.resumeme.domain.admin;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+import static org.devcourse.resumeme.common.util.Validator.Condition.isBlank;
+import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.global.advice.exception.ExceptionCode.NO_EMPTY_VALUE;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class Admin {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "admin_id")
+    private Long id;
+
+    private String email;
+
+    private String password;
+
+    public Admin(String email, String password) {
+        validate(isBlank(email), NO_EMPTY_VALUE);
+        validate(isBlank(password), NO_EMPTY_VALUE);
+
+        this.email = email;
+        this.password = password;
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/domain/admin/MentorApplication.java
+++ b/src/main/java/org/devcourse/resumeme/domain/admin/MentorApplication.java
@@ -1,0 +1,30 @@
+package org.devcourse.resumeme.domain.admin;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.global.advice.exception.ExceptionCode.NO_EMPTY_VALUE;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class MentorApplication {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "mentor_application_id")
+    private Long id;
+
+    private Long mentorId;
+
+    public MentorApplication(Long mentorId) {
+        validate(mentorId == null, NO_EMPTY_VALUE);
+
+        this.mentorId = mentorId;
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/domain/admin/MentorApplicationEvent.java
+++ b/src/main/java/org/devcourse/resumeme/domain/admin/MentorApplicationEvent.java
@@ -1,0 +1,16 @@
+package org.devcourse.resumeme.domain.admin;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+public class MentorApplicationEvent extends ApplicationEvent {
+
+    @Getter
+    private MentorApplication mentorApplication;
+
+    public MentorApplicationEvent(Object source, MentorApplication mentorApplication) {
+        super(source);
+        this.mentorApplication = mentorApplication;
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/repository/MentorApplicationRepository.java
+++ b/src/main/java/org/devcourse/resumeme/repository/MentorApplicationRepository.java
@@ -1,0 +1,8 @@
+package org.devcourse.resumeme.repository;
+
+import org.devcourse.resumeme.domain.admin.MentorApplication;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MentorApplicationRepository extends JpaRepository<MentorApplication, Long>  {
+
+}

--- a/src/main/java/org/devcourse/resumeme/service/MentorApplicationEventListener.java
+++ b/src/main/java/org/devcourse/resumeme/service/MentorApplicationEventListener.java
@@ -1,0 +1,19 @@
+package org.devcourse.resumeme.service;
+
+import lombok.RequiredArgsConstructor;
+import org.devcourse.resumeme.domain.admin.MentorApplicationEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MentorApplicationEventListener implements ApplicationListener<MentorApplicationEvent> {
+
+    private final MentorApplicationService service;
+
+    @Override
+    public void onApplicationEvent(MentorApplicationEvent event) {
+        service.create(event.getMentorApplication());
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/service/MentorApplicationService.java
+++ b/src/main/java/org/devcourse/resumeme/service/MentorApplicationService.java
@@ -1,0 +1,18 @@
+package org.devcourse.resumeme.service;
+
+import lombok.RequiredArgsConstructor;
+import org.devcourse.resumeme.domain.admin.MentorApplication;
+import org.devcourse.resumeme.repository.MentorApplicationRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MentorApplicationService {
+
+    private final MentorApplicationRepository repository;
+
+    public void create(MentorApplication mentorApplication) {
+        repository.save(mentorApplication);
+    }
+
+}


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
어드민 관련 도메인 입니다
Admin: 이메일과 비밀번호 직접 저장 해줘서 관리
MentorApplication: 멘토 가입 신청 시 저장 해둡니다

## CC. 리뷰어
@ddongpuri 다음 pr에 멘토 가입 신청 서비스 로직 만들예정인데 해당 메소드 사용하시면 됩니다

## 테스트 설명


## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
