### PR TITLE
fix: OAuth2TempInfo id값 할당 및 회원가입 후 삭제 로직 추가

### DIFF
--- a/src/main/java/org/devcourse/resumeme/controller/MenteeController.java
+++ b/src/main/java/org/devcourse/resumeme/controller/MenteeController.java
@@ -44,6 +44,7 @@ public class MenteeController {
         Mentee mentee = registerInfoRequest.toEntity(oAuth2TempInfo, refreshToken);
         Mentee savedMentee = menteeService.create(mentee);
         String accessToken = jwtService.createAccessToken(Claims.of(savedMentee));
+        oAuth2InfoRedisRepository.delete(oAuth2TempInfo);
 
         return Map.of("access", accessToken, "refresh", refreshToken);
     }

--- a/src/main/java/org/devcourse/resumeme/global/auth/OAuth2CustomUserService.java
+++ b/src/main/java/org/devcourse/resumeme/global/auth/OAuth2CustomUserService.java
@@ -61,8 +61,7 @@ public class OAuth2CustomUserService extends DefaultOAuth2UserService {
         Optional<Mentee> findMentee = menteeRepository.findByEmail(email);
 
         if (findMentor.isEmpty() && findMentee.isEmpty()) {
-
-            OAuth2TempInfo oAuth2TempInfo = new OAuth2TempInfo(userInfo.getId(), userInfo.getProvider(), userInfo.getNickname(), userInfo.getEmail(), userInfo.getImageUrl());
+            OAuth2TempInfo oAuth2TempInfo = userInfo.toOAuth2TempInfo();
             String cacheKey = oAuth2TempInfoRepository.save(oAuth2TempInfo).getId();
             log.info("Redis Temporarily saved key : {}", cacheKey);
 

--- a/src/main/java/org/devcourse/resumeme/global/auth/model/OAuth2TempInfo.java
+++ b/src/main/java/org/devcourse/resumeme/global/auth/model/OAuth2TempInfo.java
@@ -13,8 +13,8 @@ public class OAuth2TempInfo {
     private final String email;
     private final String imageUrl;
 
-    public OAuth2TempInfo(String id, String provider, String nickname, String email, String imageUrl) {
-        this.id = id;
+    public OAuth2TempInfo(String provider, String nickname, String email, String imageUrl) {
+        this.id = null;
         this.provider = provider;
         this.nickname = nickname;
         this.email = email;

--- a/src/main/java/org/devcourse/resumeme/global/auth/userInfo/OAuth2UserInfo.java
+++ b/src/main/java/org/devcourse/resumeme/global/auth/userInfo/OAuth2UserInfo.java
@@ -1,5 +1,7 @@
 package org.devcourse.resumeme.global.auth.userInfo;
 
+import org.devcourse.resumeme.global.auth.model.OAuth2TempInfo;
+
 import java.util.Map;
 
 public abstract class OAuth2UserInfo {
@@ -8,6 +10,10 @@ public abstract class OAuth2UserInfo {
 
     public OAuth2UserInfo(Map<String, Object> attributes) {
         this.attributes = attributes;
+    }
+
+    public OAuth2TempInfo toOAuth2TempInfo() {
+        return new OAuth2TempInfo(getProvider(), getNickname(), getEmail(), getImageUrl());
     }
 
     public abstract String getId();

--- a/src/test/java/org/devcourse/resumeme/controller/MenteeControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/controller/MenteeControllerTest.java
@@ -36,7 +36,7 @@ class MenteeControllerTest extends ControllerUnitTest {
         // given
         RequiredInfoRequest requiredInfoRequest = new RequiredInfoRequest("nickname", "realName", "01034548443", Role.ROLE_MENTEE);
         MenteeRegisterInfoRequest menteeRegisterInfoRequest = new MenteeRegisterInfoRequest("cacheKey", requiredInfoRequest, Set.of("FRONT", "BACK"), Set.of("RETAIL", "MANUFACTURE"), "안녕하세요 백둥이 4기 머쓱이입니다.");
-        OAuth2TempInfo oAuth2TempInfo = new OAuth2TempInfo("cacheKey", "KAKAO", "지롱", "devcoco@naver.com", "image.png");
+        OAuth2TempInfo oAuth2TempInfo = new OAuth2TempInfo("KAKAO", "지롱", "devcoco@naver.com", "image.png");
 
         Mentee mentee = menteeRegisterInfoRequest.toEntity(oAuth2TempInfo, "refreshTokenRecentlyIssued");
         Mentee savedMentee = Mentee.builder()

--- a/src/test/java/org/devcourse/resumeme/controller/MentorApplicationControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/controller/MentorApplicationControllerTest.java
@@ -49,7 +49,7 @@ class MentorApplicationControllerTest extends ControllerUnitTest {
     void SetUP() {
         requiredInfoRequest = new RequiredInfoRequest("nickname", "realName", "01034548443", Role.ROLE_PENDING);
         mentorRegisterInfoRequest = new MentorRegisterInfoRequest("cacheKey", requiredInfoRequest, Set.of("FRONT", "BACK"), "A회사 00팀, B회사 xx팀", 3, "안녕하세요 멘토가 되고싶어요.");
-        oAuth2TempInfo = new OAuth2TempInfo("cacheKey", "GOOGLE", "지롱", "devcoco@naver.com", "image.png");
+        oAuth2TempInfo = new OAuth2TempInfo("GOOGLE", "지롱", "devcoco@naver.com", "image.png");
         refreshToken = "refreshTokenRecentlyIssued";
     }
 

--- a/src/test/java/org/devcourse/resumeme/controller/MentorControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/controller/MentorControllerTest.java
@@ -52,7 +52,7 @@ class MentorControllerTest extends ControllerUnitTest {
     void setUp() {
         requiredInfoRequest = new RequiredInfoRequest("nickname", "realName", "01034548443", Role.ROLE_PENDING);
         mentorRegisterInfoRequest = new MentorRegisterInfoRequest("cacheKey", requiredInfoRequest, Set.of("FRONT", "BACK"), "A회사 00팀, B회사 xx팀", 3, "안녕하세요 멘토가 되고싶어요.");
-        oAuth2TempInfo = new OAuth2TempInfo("cacheKey", "GOOGLE", "지롱", "devcoco@naver.com", "image.png");
+        oAuth2TempInfo = new OAuth2TempInfo("GOOGLE", "지롱", "devcoco@naver.com", "image.png");
 
         mentor = mentorRegisterInfoRequest.toEntity(oAuth2TempInfo, "refreshTokenRecentlyIssued");
     }

--- a/src/test/java/org/devcourse/resumeme/domain/mentor/MentorTest.java
+++ b/src/test/java/org/devcourse/resumeme/domain/mentor/MentorTest.java
@@ -31,7 +31,7 @@ class MentorTest {
     void SetUP() {
         requiredInfoRequest = new RequiredInfoRequest("nickname", "realName", "01034548443", Role.ROLE_PENDING);
         mentorRegisterInfoRequest = new MentorRegisterInfoRequest("cacheKey", requiredInfoRequest, Set.of("FRONT", "BACK"), "A회사 00팀, B회사 xx팀", 3, "안녕하세요 멘토가 되고싶어요.");
-        oAuth2TempInfo = new OAuth2TempInfo("cacheKey", "GOOGLE", "지롱", "devcoco@naver.com", "image.png");
+        oAuth2TempInfo = new OAuth2TempInfo( "GOOGLE", "지롱", "devcoco@naver.com", "image.png");
         refreshToken = "refreshTokenRecentlyIssued";
     }
 


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
- 회원가입 완료 후에도 Redis에 소셜로그인 관련 정보가 남아있어 똑같은 정보로 재차 회원가입이 가능한 문제
-> 회원가입 완료 후 redis에 있는 정보 삭제해줌
- OAuth2TempInfo id 로 랜덤값이 할당되지 않았던 문제
-> id로 null을 넘겨줄 경우 랜덤값이 할당됨

## CC. 리뷰어
테스트 코드는 변경사항 관련되어 수정된 것들이라 보실 필요 없습니다~

## 테스트 설명


## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
