### PR TITLE
feat: 이벤트 단건 조회 역할 별 반환 값 분리

### DIFF
--- a/src/test/java/org/devcourse/resumeme/common/DocumentLinkGenerator.java
+++ b/src/test/java/org/devcourse/resumeme/common/DocumentLinkGenerator.java
@@ -8,7 +8,8 @@ public interface DocumentLinkGenerator {
 
     enum DocUrl {
         POSITION("position", "포지션"),
-        EVENT_STATUS("eventStatus", "이벤트 상태")
+        EVENT_STATUS("eventStatus", "이벤트 상태"),
+        PROGRESS("progress", "이벤트 참여 상태")
         ;
 
         private final String htmlFileName;

--- a/src/test/java/org/devcourse/resumeme/controller/EventControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/controller/EventControllerTest.java
@@ -32,6 +32,7 @@ import java.util.Set;
 
 import static org.devcourse.resumeme.common.DocumentLinkGenerator.DocUrl.EVENT_STATUS;
 import static org.devcourse.resumeme.common.DocumentLinkGenerator.DocUrl.POSITION;
+import static org.devcourse.resumeme.common.DocumentLinkGenerator.DocUrl.PROGRESS;
 import static org.devcourse.resumeme.common.DocumentLinkGenerator.generateLinkCode;
 import static org.devcourse.resumeme.common.domain.Position.BACK;
 import static org.devcourse.resumeme.common.domain.Position.FRONT;
@@ -191,6 +192,7 @@ class EventControllerTest extends ControllerUnitTest {
     }
 
     @Test
+    @WithMockCustomUser(role = "ROLE_MENTOR")
     void 첨삭_이벤트에_참여한_이력서를_조회할수있다() throws Exception {
         // given
         Long eventId = 1L;
@@ -221,14 +223,14 @@ class EventControllerTest extends ControllerUnitTest {
                                 ),
                                 responseFields(
                                         fieldWithPath("info").type(OBJECT).description("이벤트 관련 정보"),
-                                        fieldWithPath("info.title").type(STRING).description(""),
-                                        fieldWithPath("info.maximumCount").type(NUMBER).description(""),
-                                        fieldWithPath("info.endDate").type(STRING).description(""),
-                                        fieldWithPath("resumes").type(ARRAY).description(""),
-                                        fieldWithPath("resumes[].resumeId").type(NUMBER).description(""),
-                                        fieldWithPath("resumes[].menteeName").type(STRING).description(""),
-                                        fieldWithPath("resumes[].resumeTitle").type(STRING).description(""),
-                                        fieldWithPath("resumes[].progressStatus").type(STRING).description("")
+                                        fieldWithPath("info.title").type(STRING).description("이벤트 제목"),
+                                        fieldWithPath("info.maximumCount").type(NUMBER).description("참여 최대 인원 수"),
+                                        fieldWithPath("info.endDate").type(STRING).description("첨삭 종료 일"),
+                                        fieldWithPath("resumes").type(ARRAY).description("이벤트 신청에 사용된 이력서 멘토 로그인 시에만 값 제공"),
+                                        fieldWithPath("resumes[].resumeId").type(NUMBER).description("이력서 아이디"),
+                                        fieldWithPath("resumes[].menteeName").type(STRING).description("이력서 작성 멘티 이름"),
+                                        fieldWithPath("resumes[].resumeTitle").type(STRING).description("이력서 제목"),
+                                        fieldWithPath("resumes[].progressStatus").type(STRING).description(generateLinkCode(PROGRESS))
                                 )
                         )
                 );

--- a/src/test/java/org/devcourse/resumeme/support/WithMockCustomUser.java
+++ b/src/test/java/org/devcourse/resumeme/support/WithMockCustomUser.java
@@ -11,4 +11,6 @@ public @interface WithMockCustomUser {
 
     String id() default "1";
 
+    String role() default "ROLE_MENTEE";
+
 }

--- a/src/test/java/org/devcourse/resumeme/support/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/org/devcourse/resumeme/support/WithMockCustomUserSecurityContextFactory.java
@@ -2,6 +2,7 @@ package org.devcourse.resumeme.support;
 
 import org.devcourse.resumeme.global.auth.model.JwtUser;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithSecurityContextFactory;
@@ -13,7 +14,7 @@ public class WithMockCustomUserSecurityContextFactory implements WithSecurityCon
     @Override
     public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
         SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-        securityContext.setAuthentication(new UsernamePasswordAuthenticationToken(new JwtUser(Long.parseLong(annotation.id())), null, List.of(() -> "ROLE_USER")));
+        securityContext.setAuthentication(new UsernamePasswordAuthenticationToken(new JwtUser(Long.parseLong(annotation.id())), null, List.of(annotation::role)));
 
         return securityContext;
     }


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
이벤트 단건 조회 역할 별 반환 값 분리

## CC. 리뷰어
멘토일 경우에는 어떤 이력서가 들어왔는지까지 포함을 해야하고 멘티는 이벤트에 대한 기본 정보만을 가지면 되기때문에 역할 별 반환 값을 분리했고 테스트는 멘토 기준으로 작성하고 description 을 적어뒀습니다

## 테스트 설명
- WithMockCustomUser, WithMockCustomUserSecurityContextFactory : 어노테이션 옵션으로 role이 추가되었습니다

## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
