### PR TITLE
chore: validator 메소드명 수정

### DIFF
--- a/src/main/java/org/devcourse/resumeme/common/util/Validator.java
+++ b/src/main/java/org/devcourse/resumeme/common/util/Validator.java
@@ -10,13 +10,13 @@ import static lombok.AccessLevel.PRIVATE;
 @NoArgsConstructor(access = PRIVATE)
 public class Validator {
 
-    public static void validate(boolean predicate, String errorCode, String errorMessage) {
+    public static void check(boolean predicate, String errorCode, String errorMessage) {
         if (predicate) {
             throw new CustomException(errorCode, errorMessage);
         }
     }
 
-    public static void validate(boolean predicate, ExceptionCode exceptionCode) {
+    public static void check(boolean predicate, ExceptionCode exceptionCode) {
         if (predicate) {
             throw new CustomException(exceptionCode);
         }

--- a/src/main/java/org/devcourse/resumeme/domain/admin/Admin.java
+++ b/src/main/java/org/devcourse/resumeme/domain/admin/Admin.java
@@ -5,10 +5,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import lombok.NoArgsConstructor;
+import org.devcourse.resumeme.common.util.Validator;
 
 import static lombok.AccessLevel.PROTECTED;
 import static org.devcourse.resumeme.common.util.Validator.Condition.isBlank;
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 import static org.devcourse.resumeme.global.advice.exception.ExceptionCode.NO_EMPTY_VALUE;
 
 @Entity
@@ -25,8 +26,8 @@ public class Admin {
     private String password;
 
     public Admin(String email, String password) {
-        validate(isBlank(email), NO_EMPTY_VALUE);
-        validate(isBlank(password), NO_EMPTY_VALUE);
+        Validator.check(isBlank(email), NO_EMPTY_VALUE);
+        Validator.check(isBlank(password), NO_EMPTY_VALUE);
 
         this.email = email;
         this.password = password;

--- a/src/main/java/org/devcourse/resumeme/domain/admin/MentorApplication.java
+++ b/src/main/java/org/devcourse/resumeme/domain/admin/MentorApplication.java
@@ -8,11 +8,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.devcourse.resumeme.common.util.Validator;
 import org.devcourse.resumeme.domain.mentor.Mentor;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 import static org.devcourse.resumeme.global.advice.exception.ExceptionCode.NO_EMPTY_VALUE;
 
 @Entity
@@ -30,7 +31,7 @@ public class MentorApplication {
     private Mentor mentor;
 
     public MentorApplication(Mentor mentor) {
-        validate(mentor == null, NO_EMPTY_VALUE);
+        Validator.check(mentor == null, NO_EMPTY_VALUE);
 
         this.mentor = mentor;
     }

--- a/src/main/java/org/devcourse/resumeme/domain/event/Event.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/Event.java
@@ -23,7 +23,7 @@ import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.CascadeType.REMOVE;
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)
@@ -64,10 +64,10 @@ public class Event extends BaseEntity {
     }
 
     private void validateInput(EventInfo eventInfo, EventTimeInfo eventTimeInfo, Mentor mentor, List<Position> positions) {
-        validate(eventInfo == null, "NO_EMPTY_VALUE", "빈 값일 수 없습니다");
-        validate(eventTimeInfo == null, "NO_EMPTY_VALUE", "빈 값일 수 없습니다");
-        validate(mentor == null, "NO_EMPTY_VALUE", "빈 값일 수 없습니다");
-        validate(positions == null, "NO_EMPTY_VALUE", "빈 값일 수 없습니다");
+        check(eventInfo == null, "NO_EMPTY_VALUE", "빈 값일 수 없습니다");
+        check(eventTimeInfo == null, "NO_EMPTY_VALUE", "빈 값일 수 없습니다");
+        check(mentor == null, "NO_EMPTY_VALUE", "빈 값일 수 없습니다");
+        check(positions == null, "NO_EMPTY_VALUE", "빈 값일 수 없습니다");
     }
 
     public int acceptMentee(Long menteeId, Long resumeId) {

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventInfo.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventInfo.java
@@ -9,7 +9,7 @@ import org.devcourse.resumeme.domain.event.exception.EventException;
 import static jakarta.persistence.EnumType.STRING;
 import static lombok.AccessLevel.PROTECTED;
 import static org.devcourse.resumeme.common.util.Validator.Condition.isBlank;
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 
 @Embeddable
 @NoArgsConstructor(access = PROTECTED)
@@ -37,9 +37,9 @@ public class EventInfo {
     }
 
     private void validateInput(int maximumAttendee, String title, String content) {
-        validate(maximumAttendee < 2 || maximumAttendee > 10, "RANGE_MAXIMUM_ATTENDEE", "참여 인원 수를 2~10명 사이에서 정해주세요");
-        validate(isBlank(title), "NO_EMPTY_STRING", "제목은 필수 값입니다");
-        validate(isBlank(content), "NO_EMPTY_STRING", "내용은 필수 값입니다");
+        check(maximumAttendee < 2 || maximumAttendee > 10, "RANGE_MAXIMUM_ATTENDEE", "참여 인원 수를 2~10명 사이에서 정해주세요");
+        check(isBlank(title), "NO_EMPTY_STRING", "제목은 필수 값입니다");
+        check(isBlank(content), "NO_EMPTY_STRING", "내용은 필수 값입니다");
     }
 
     public static EventInfo open(int maximumAttendee, String title, String content) {

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventPosition.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventPosition.java
@@ -14,7 +14,7 @@ import org.devcourse.resumeme.common.domain.Position;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)
@@ -34,8 +34,8 @@ public class EventPosition {
     private Event event;
 
     public EventPosition(Position position, Event event) {
-        validate(position == null, "NO_EMPTY_VALUE", "포지션은 필수 값입니다");
-        validate(event == null, "NO_EMPTY_VALUE", "이벤트는 필수 값입니다");
+        check(position == null, "NO_EMPTY_VALUE", "포지션은 필수 값입니다");
+        check(event == null, "NO_EMPTY_VALUE", "이벤트는 필수 값입니다");
 
         this.position = position;
         this.event = event;

--- a/src/main/java/org/devcourse/resumeme/domain/event/EventTimeInfo.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/EventTimeInfo.java
@@ -8,7 +8,7 @@ import org.devcourse.resumeme.domain.event.exception.EventException;
 import java.time.LocalDateTime;
 
 import static lombok.AccessLevel.PROTECTED;
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 
 @Embeddable
 @NoArgsConstructor(access = PROTECTED)
@@ -30,11 +30,11 @@ public class EventTimeInfo {
     }
 
     private void validateInput(LocalDateTime openDateTime, LocalDateTime closeDateTime, LocalDateTime endDate) {
-        validate(openDateTime == null, "NO_EMPTY_VALUE", "시작 시간은 빈 값일 수 없습니다");
-        validate(closeDateTime == null, "NO_EMPTY_VALUE", "시작 시간은 빈 값일 수 없습니다");
-        validate(endDate == null, "NO_EMPTY_VALUE", "종료 시간은 빈 값일 수 없습니다");
-        validate(openDateTime.isAfter(closeDateTime), "TIME_ERROR", "시작 시간이 신청 마감 시간보다 빨라야 합니다");
-        validate(closeDateTime.isAfter(endDate), "TIME_ERROR", "신청 마감 시간이 종료 시간보다 빨라야 합니다");
+        check(openDateTime == null, "NO_EMPTY_VALUE", "시작 시간은 빈 값일 수 없습니다");
+        check(closeDateTime == null, "NO_EMPTY_VALUE", "시작 시간은 빈 값일 수 없습니다");
+        check(endDate == null, "NO_EMPTY_VALUE", "종료 시간은 빈 값일 수 없습니다");
+        check(openDateTime.isAfter(closeDateTime), "TIME_ERROR", "시작 시간이 신청 마감 시간보다 빨라야 합니다");
+        check(closeDateTime.isAfter(endDate), "TIME_ERROR", "신청 마감 시간이 종료 시간보다 빨라야 합니다");
     }
 
     public static EventTimeInfo onStart(LocalDateTime nowDateTime, LocalDateTime closeDateTime, LocalDateTime endDate) {
@@ -42,7 +42,7 @@ public class EventTimeInfo {
     }
 
     public static EventTimeInfo book(LocalDateTime nowDateTime, LocalDateTime openDateTime, LocalDateTime closeDateTime, LocalDateTime endDate) {
-        validate(openDateTime == null, "NO_EMPTY_VALUE", "시작 시간은 빈 값일 수 없습니다");
+        check(openDateTime == null, "NO_EMPTY_VALUE", "시작 시간은 빈 값일 수 없습니다");
         if (openDateTime.isBefore(nowDateTime)) {
             throw new EventException("CAN_NOT_RESERVATION", "현재 시간보다 이전 시간으로는 예약할 수 없습니다");
         }

--- a/src/main/java/org/devcourse/resumeme/domain/event/MenteeToEvent.java
+++ b/src/main/java/org/devcourse/resumeme/domain/event/MenteeToEvent.java
@@ -12,7 +12,7 @@ import org.devcourse.resumeme.common.domain.BaseEntity;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 import static org.devcourse.resumeme.domain.event.Progress.APPLY;
 import static org.devcourse.resumeme.domain.event.Progress.REJECT;
 import static org.devcourse.resumeme.domain.event.Progress.REQUEST;
@@ -43,9 +43,9 @@ public class MenteeToEvent extends BaseEntity {
     private String rejectMessage;
 
     public MenteeToEvent(Event event, Long menteeId, Long resumeId) {
-        validate(event == null, "NOT_EMPTY_VALUE", "이벤트는 빈 값일 수 없습니다");
-        validate(menteeId == null, "NOT_EMPTY_VALUE", "멘티는 빈 값일 수 없습니다");
-        validate(resumeId == null, "NOT_EMPTY_VALUE", "이력서는 빈 값일 수 없습니다");
+        check(event == null, "NOT_EMPTY_VALUE", "이벤트는 빈 값일 수 없습니다");
+        check(menteeId == null, "NOT_EMPTY_VALUE", "멘티는 빈 값일 수 없습니다");
+        check(resumeId == null, "NOT_EMPTY_VALUE", "이력서는 빈 값일 수 없습니다");
 
         this.event = event;
         this.menteeId = menteeId;
@@ -59,7 +59,7 @@ public class MenteeToEvent extends BaseEntity {
     }
 
     public void reject(String rejectMessage) {
-        validate(rejectMessage == null, "NOT_EMPTY_VALUE", "반려 사유를 작성해주세요");
+        check(rejectMessage == null, "NOT_EMPTY_VALUE", "반려 사유를 작성해주세요");
 
         this.rejectMessage = rejectMessage;
         this.progress = REJECT;

--- a/src/main/java/org/devcourse/resumeme/domain/mentee/MenteeField.java
+++ b/src/main/java/org/devcourse/resumeme/domain/mentee/MenteeField.java
@@ -13,7 +13,7 @@ import org.devcourse.resumeme.common.domain.Field;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)
@@ -32,8 +32,8 @@ public class MenteeField {
     private Field field;
 
     public MenteeField(Mentee mentee, Field field) {
-        validate(field == null, "NO_EMPTY_VALUE", "분야는 필수 값입니다");
-        validate(mentee == null, "NO_EMPTY_VALUE", "사용자는 필수 값입니다");
+        check(field == null, "NO_EMPTY_VALUE", "분야는 필수 값입니다");
+        check(mentee == null, "NO_EMPTY_VALUE", "사용자는 필수 값입니다");
 
         this.mentee = mentee;
         this.field = field;

--- a/src/main/java/org/devcourse/resumeme/domain/mentee/MenteePosition.java
+++ b/src/main/java/org/devcourse/resumeme/domain/mentee/MenteePosition.java
@@ -14,7 +14,7 @@ import org.devcourse.resumeme.common.domain.Position;
 
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -35,8 +35,8 @@ public class MenteePosition {
     private Position position;
 
     public MenteePosition(Mentee mentee, Position position) {
-        validate(position == null, "NO_EMPTY_VALUE", "포지션은 필수 값입니다");
-        validate(mentee == null, "NO_EMPTY_VALUE", "사용자는 필수 값입니다");
+        check(position == null, "NO_EMPTY_VALUE", "포지션은 필수 값입니다");
+        check(mentee == null, "NO_EMPTY_VALUE", "사용자는 필수 값입니다");
 
         this.position = position;
         this.mentee = mentee;

--- a/src/main/java/org/devcourse/resumeme/domain/mentee/RequiredInfo.java
+++ b/src/main/java/org/devcourse/resumeme/domain/mentee/RequiredInfo.java
@@ -7,10 +7,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.devcourse.resumeme.common.util.Validator;
 import org.devcourse.resumeme.domain.user.Role;
 import org.devcourse.resumeme.global.advice.exception.ExceptionCode;
 
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -63,19 +64,19 @@ public class RequiredInfo {
     }
 
     private void validateNickname(String nickname) {
-        validate(nickname == null || nickname.isBlank(), "INVALID_TEXT", "닉네임이 유효하지 않습니다.");
+        check(nickname == null || nickname.isBlank(), "INVALID_TEXT", "닉네임이 유효하지 않습니다.");
     }
 
     private void validateRealName(String realName) {
-        validate(realName == null || realName.isBlank(), "INVALID_TEXT", "이름이 유효하지 않습니다.");
+        check(realName == null || realName.isBlank(), "INVALID_TEXT", "이름이 유효하지 않습니다.");
     }
 
     private void validatePhoneNumber(String phoneNumber) {
-        validate(phoneNumber == null || !(phoneNumber.matches(PHONE_REGEX)), "INVALID_TEXT", "전화번호가 유효하지 않습니다.");
+        check(phoneNumber == null || !(phoneNumber.matches(PHONE_REGEX)), "INVALID_TEXT", "전화번호가 유효하지 않습니다.");
     }
 
     private void validateUserRole(Role role) {
-        validate(Role.ROLE_ADMIN.equals(role), ExceptionCode.ROLE_NOT_ALLOWED);
+        Validator.check(Role.ROLE_ADMIN.equals(role), ExceptionCode.ROLE_NOT_ALLOWED);
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/domain/mentor/Mentor.java
+++ b/src/main/java/org/devcourse/resumeme/domain/mentor/Mentor.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.devcourse.resumeme.common.domain.BaseEntity;
 import org.devcourse.resumeme.common.domain.Position;
+import org.devcourse.resumeme.common.util.Validator;
 import org.devcourse.resumeme.domain.mentee.RequiredInfo;
 import org.devcourse.resumeme.domain.user.Provider;
 import org.devcourse.resumeme.domain.user.Role;
@@ -23,7 +24,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static jakarta.persistence.FetchType.LAZY;
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 import static org.devcourse.resumeme.domain.user.Role.ROLE_ADMIN;
 import static org.devcourse.resumeme.domain.user.Role.ROLE_MENTEE;
 import static org.devcourse.resumeme.domain.user.Role.ROLE_MENTOR;
@@ -87,15 +88,15 @@ public class Mentor extends BaseEntity {
     }
 
     private void validateInputs(String email, Provider provider, String imageUrl, RequiredInfo requiredInfo, String refreshToken, Set<String> experiencedPositions, String careerContent, int careerYear, String introduce) {
-        validate(email == null || email.isBlank() || !email.matches(EMAIL_REGEX), "INVALID_EMAIL", "이메일이 유효하지 않습니다.");
-        validate(provider == null, NO_EMPTY_VALUE);
-        validate(imageUrl == null || imageUrl.isBlank(), NO_EMPTY_VALUE);
-        validate(requiredInfo == null, NO_EMPTY_VALUE);
-        validate(ROLE_MENTEE.equals(requiredInfo.getRole()) || ROLE_ADMIN.equals(requiredInfo.getRole()), ROLE_NOT_ALLOWED);
-        validate(refreshToken == null || refreshToken.isBlank(), NO_EMPTY_VALUE);
-        validate(experiencedPositions == null || experiencedPositions.size() == 0, NO_EMPTY_VALUE);
-        validate(careerContent == null || careerContent.isBlank(), NO_EMPTY_VALUE);
-        validate(careerYear < 1 || careerYear > 80, "NUMBER_NOT_ALLOWED", "경력 연차가 올바르지 않습니다.");
+        check(email == null || email.isBlank() || !email.matches(EMAIL_REGEX), "INVALID_EMAIL", "이메일이 유효하지 않습니다.");
+        Validator.check(provider == null, NO_EMPTY_VALUE);
+        Validator.check(imageUrl == null || imageUrl.isBlank(), NO_EMPTY_VALUE);
+        Validator.check(requiredInfo == null, NO_EMPTY_VALUE);
+        Validator.check(ROLE_MENTEE.equals(requiredInfo.getRole()) || ROLE_ADMIN.equals(requiredInfo.getRole()), ROLE_NOT_ALLOWED);
+        Validator.check(refreshToken == null || refreshToken.isBlank(), NO_EMPTY_VALUE);
+        Validator.check(experiencedPositions == null || experiencedPositions.size() == 0, NO_EMPTY_VALUE);
+        Validator.check(careerContent == null || careerContent.isBlank(), NO_EMPTY_VALUE);
+        check(careerYear < 1 || careerYear > 80, "NUMBER_NOT_ALLOWED", "경력 연차가 올바르지 않습니다.");
     }
 
     public void updateRefreshToken(String refreshToken) {

--- a/src/main/java/org/devcourse/resumeme/domain/mentor/MentorPosition.java
+++ b/src/main/java/org/devcourse/resumeme/domain/mentor/MentorPosition.java
@@ -13,7 +13,7 @@ import org.devcourse.resumeme.common.domain.Position;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)
@@ -32,8 +32,8 @@ public class MentorPosition {
     private Position position;
 
     public MentorPosition(Mentor mentor, Position position) {
-        validate(position == null, "NO_EMPTY_VALUE", "포지션은 필수 값입니다");
-        validate(mentor == null, "NO_EMPTY_VALUE", "사용자는 필수 값입니다");
+        check(position == null, "NO_EMPTY_VALUE", "포지션은 필수 값입니다");
+        check(mentor == null, "NO_EMPTY_VALUE", "사용자는 필수 값입니다");
 
         this.position = position;
         this.mentor = mentor;

--- a/src/main/java/org/devcourse/resumeme/domain/resume/Activity.java
+++ b/src/main/java/org/devcourse/resumeme/domain/resume/Activity.java
@@ -9,11 +9,12 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.devcourse.resumeme.common.util.Validator;
 import org.devcourse.resumeme.global.advice.exception.ExceptionCode;
 
 import java.time.LocalDate;
 
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -42,9 +43,9 @@ public class Activity {
     private String description;
 
     public Activity(String activityName, LocalDate startDate, LocalDate endDate, boolean inProgress, String link, String description) {
-        validate(activityName == null, ExceptionCode.NO_EMPTY_VALUE);
-        validate(startDate == null, ExceptionCode.NO_EMPTY_VALUE);
-        validate(endDate == null && !inProgress, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(activityName == null, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(startDate == null, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(endDate == null && !inProgress, ExceptionCode.NO_EMPTY_VALUE);
 
         this.activityName = activityName;
         this.startDate = startDate;

--- a/src/main/java/org/devcourse/resumeme/domain/resume/Career.java
+++ b/src/main/java/org/devcourse/resumeme/domain/resume/Career.java
@@ -16,6 +16,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.devcourse.resumeme.common.domain.Position;
+import org.devcourse.resumeme.common.util.Validator;
 import org.devcourse.resumeme.global.advice.exception.CustomException;
 import org.devcourse.resumeme.global.advice.exception.ExceptionCode;
 
@@ -23,7 +24,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -77,13 +78,13 @@ public class Career {
     }
 
     private void validateCareer(String companyName, Position position, List<String> skills, List<Duty> duties, boolean isCurrentlyEmployed, LocalDate careerStartDate, LocalDate endDate) {
-        validate(companyName == null, ExceptionCode.NO_EMPTY_VALUE);
-        validate(position == null, ExceptionCode.NO_EMPTY_VALUE);
-        validate(skills.isEmpty(), ExceptionCode.NO_EMPTY_VALUE);
-        validate(duties.isEmpty(), ExceptionCode.NO_EMPTY_VALUE);
-        validate(careerStartDate == null, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(companyName == null, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(position == null, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(skills.isEmpty(), ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(duties.isEmpty(), ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(careerStartDate == null, ExceptionCode.NO_EMPTY_VALUE);
         if (isCurrentlyEmployed) {
-            validate(endDate == null, ExceptionCode.NO_EMPTY_VALUE);
+            Validator.check(endDate == null, ExceptionCode.NO_EMPTY_VALUE);
         }
 
         if (careerStartDate.isAfter(endDate)) {

--- a/src/main/java/org/devcourse/resumeme/domain/resume/Certification.java
+++ b/src/main/java/org/devcourse/resumeme/domain/resume/Certification.java
@@ -9,10 +9,11 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.devcourse.resumeme.common.util.Validator;
 import org.devcourse.resumeme.global.advice.exception.ExceptionCode;
 
 import static org.devcourse.resumeme.common.util.Validator.Condition.isBlank;
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -39,7 +40,7 @@ public class Certification {
     private String description;
 
     public Certification(String certificationTitle, String acquisitionDate, String issuingAuthority, String link, String description) {
-        validate(isBlank(certificationTitle), ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(isBlank(certificationTitle), ExceptionCode.NO_EMPTY_VALUE);
 
         this.certificationTitle = certificationTitle;
         this.acquisitionDate = acquisitionDate;

--- a/src/main/java/org/devcourse/resumeme/domain/resume/Duty.java
+++ b/src/main/java/org/devcourse/resumeme/domain/resume/Duty.java
@@ -9,12 +9,13 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.devcourse.resumeme.common.util.Validator;
 import org.devcourse.resumeme.global.advice.exception.CustomException;
 import org.devcourse.resumeme.global.advice.exception.ExceptionCode;
 
 import java.time.LocalDate;
 
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Duty {
@@ -48,9 +49,9 @@ public class Duty {
     }
 
     private void validateDuty(String title, LocalDate startDate, LocalDate endDate) {
-        validate(title == null, ExceptionCode.NO_EMPTY_VALUE);
-        validate(startDate == null, ExceptionCode.NO_EMPTY_VALUE);
-        validate(endDate == null, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(title == null, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(startDate == null, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(endDate == null, ExceptionCode.NO_EMPTY_VALUE);
 
         if (startDate.isAfter(endDate)) {
             throw new CustomException("TIME_ERROR", "시작일은 종료일보다 먼저여야 합니다.");

--- a/src/main/java/org/devcourse/resumeme/domain/resume/ForeignLanguage.java
+++ b/src/main/java/org/devcourse/resumeme/domain/resume/ForeignLanguage.java
@@ -9,9 +9,10 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.devcourse.resumeme.common.util.Validator;
 import org.devcourse.resumeme.global.advice.exception.ExceptionCode;
 
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -34,9 +35,9 @@ public class ForeignLanguage {
     private String scoreOrGrade;
 
     public ForeignLanguage(String language, String examName, String scoreOrGrade, Resume resume) {
-        validate(language == null, ExceptionCode.NO_EMPTY_VALUE);
-        validate(examName == null, ExceptionCode.NO_EMPTY_VALUE);
-        validate(scoreOrGrade == null, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(language == null, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(examName == null, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(scoreOrGrade == null, ExceptionCode.NO_EMPTY_VALUE);
 
         this.resume = resume;
         this.language = language;

--- a/src/main/java/org/devcourse/resumeme/domain/resume/Project.java
+++ b/src/main/java/org/devcourse/resumeme/domain/resume/Project.java
@@ -3,7 +3,6 @@ package org.devcourse.resumeme.domain.resume;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Embeddable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -12,12 +11,12 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.devcourse.resumeme.common.util.Validator;
 import org.devcourse.resumeme.global.advice.exception.ExceptionCode;
 
-import java.time.LocalDate;
 import java.util.List;
 
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -67,8 +66,8 @@ public class Project {
     }
 
     private void validateProject(String projectName, Long productionYear) {
-        validate(projectName == null, ExceptionCode.NO_EMPTY_VALUE);
-        validate(productionYear == null, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(projectName == null, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(productionYear == null, ExceptionCode.NO_EMPTY_VALUE);
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/domain/resume/Resume.java
+++ b/src/main/java/org/devcourse/resumeme/domain/resume/Resume.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.devcourse.resumeme.common.domain.BaseEntity;
 import org.devcourse.resumeme.common.domain.Position;
+import org.devcourse.resumeme.common.util.Validator;
 import org.devcourse.resumeme.domain.mentee.Mentee;
 import org.devcourse.resumeme.global.advice.exception.ExceptionCode;
 
@@ -23,7 +24,7 @@ import java.util.List;
 
 import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.CascadeType.REMOVE;
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -80,8 +81,8 @@ public class Resume extends BaseEntity {
     }
 
     private static void validateResume(String title, Mentee mentee) {
-        validate(title == null, ExceptionCode.NO_EMPTY_VALUE);
-        validate(mentee == null, ExceptionCode.MENTEE_NOT_FOUND);
+        Validator.check(title == null, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(mentee == null, ExceptionCode.MENTEE_NOT_FOUND);
     }
 
     private Resume(Long id, String title, Mentee mentee, Position position, String introduce, List<Career> career,

--- a/src/main/java/org/devcourse/resumeme/domain/resume/Training.java
+++ b/src/main/java/org/devcourse/resumeme/domain/resume/Training.java
@@ -9,10 +9,11 @@ import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.devcourse.resumeme.common.util.Validator;
 import org.devcourse.resumeme.global.advice.exception.CustomException;
 import org.devcourse.resumeme.global.advice.exception.ExceptionCode;
 
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 
 import java.time.LocalDate;
 
@@ -63,11 +64,11 @@ public class Training {
 
     private void validateTraining(String schoolOrOrganization, String major, String degree, LocalDate admissionDate,
                                LocalDate graduationDate, double gpa, double maxGpa) {
-        validate(schoolOrOrganization == null, ExceptionCode.NO_EMPTY_VALUE);
-        validate(major == null, ExceptionCode.NO_EMPTY_VALUE);
-        validate(degree == null, ExceptionCode.NO_EMPTY_VALUE);
-        validate(admissionDate == null, ExceptionCode.NO_EMPTY_VALUE);
-        validate(graduationDate == null, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(schoolOrOrganization == null, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(major == null, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(degree == null, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(admissionDate == null, ExceptionCode.NO_EMPTY_VALUE);
+        Validator.check(graduationDate == null, ExceptionCode.NO_EMPTY_VALUE);
 
         if (admissionDate.isAfter(graduationDate)) {
             throw new CustomException("TIME_ERROR", "입학 일시는 졸업 일시보다 먼저여야 합니다.");

--- a/src/main/java/org/devcourse/resumeme/domain/review/Review.java
+++ b/src/main/java/org/devcourse/resumeme/domain/review/Review.java
@@ -10,6 +10,7 @@ import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.devcourse.resumeme.common.domain.BaseEntity;
+import org.devcourse.resumeme.common.util.Validator;
 import org.devcourse.resumeme.domain.resume.BlockType;
 import org.devcourse.resumeme.domain.resume.Resume;
 
@@ -17,7 +18,7 @@ import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
 import static org.devcourse.resumeme.common.util.Validator.Condition.isBlank;
-import static org.devcourse.resumeme.common.util.Validator.validate;
+import static org.devcourse.resumeme.common.util.Validator.check;
 import static org.devcourse.resumeme.global.advice.exception.ExceptionCode.NO_EMPTY_VALUE;
 
 @Entity
@@ -42,9 +43,9 @@ public class Review extends BaseEntity {
     private Resume resume;
 
     public Review(String content, BlockType type, Resume resume) {
-        validate(isBlank(content), NO_EMPTY_VALUE);
-        validate(type == null, NO_EMPTY_VALUE);
-        validate(resume == null, NO_EMPTY_VALUE);
+        Validator.check(isBlank(content), NO_EMPTY_VALUE);
+        Validator.check(type == null, NO_EMPTY_VALUE);
+        Validator.check(resume == null, NO_EMPTY_VALUE);
 
         this.content = content;
         this.type = type;


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
validator 메소드명 수정

## CC. 리뷰어
이전에 멘토님과 이야기 중 `Validator.validate()` 메소드에서 validate가 확인, 보장한다 라는 뜻을 가지고 있는데 exception 관련 처리를 하는데 메소드명이 예외를 보장한다? 라는게 뭔가 이상하다 해서 예외를 확인한다라는 뜻으로 check로 변경했습니다

혹시 다른 더 좋은 이름 생각나시면 말씀해주세요

아마 많이 conflict가 날 것 같으니 해당 pr은 다른 분들 현재 하고있는 것들 pr 올리고 닫으면 그 뒤에 바로 닫을게요

## 테스트 설명


## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
