### PR TITLE
feat: JwtService 로직 및 토큰 헤더 이름 수정

### DIFF
--- a/src/main/java/org/devcourse/resumeme/business/user/controller/mentee/MenteeController.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/controller/mentee/MenteeController.java
@@ -11,8 +11,8 @@ import org.devcourse.resumeme.common.response.IdResponse;
 import org.devcourse.resumeme.global.auth.model.jwt.Claims;
 import org.devcourse.resumeme.global.auth.model.login.OAuth2TempInfo;
 import org.devcourse.resumeme.global.auth.service.jwt.JwtService;
+import org.devcourse.resumeme.global.auth.service.jwt.Token;
 import org.devcourse.resumeme.global.auth.service.login.OAuth2InfoRedisService;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -41,12 +41,13 @@ public class MenteeController {
 
         Mentee mentee = registerInfoRequest.toEntity(oAuth2TempInfo);
         Mentee savedMentee = menteeService.create(mentee);
-        HttpHeaders tokens = jwtService.createTokens(Claims.of(savedMentee));
-        menteeService.updateRefreshToken(savedMentee.getId(), tokens.getFirst("Refresh-Token"));
+        Token token = jwtService.createTokens(Claims.of(savedMentee));
+        menteeService.updateRefreshToken(savedMentee.getId(), token.refreshToken());
         oAuth2InfoRedisService.delete(oAuth2TempInfo.getId());
 
         return ResponseEntity.status(200)
-                .headers(tokens)
+                .header(token.getAccessTokenName(), token.accessToken())
+                .header(token.getRefreshTokenName(), token.refreshToken())
                 .build();
     }
 

--- a/src/main/java/org/devcourse/resumeme/business/user/controller/mentee/MenteeController.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/controller/mentee/MenteeController.java
@@ -2,16 +2,17 @@ package org.devcourse.resumeme.business.user.controller.mentee;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.devcourse.resumeme.business.user.controller.mentee.dto.MenteeInfoResponse;
 import org.devcourse.resumeme.business.user.controller.mentee.dto.MenteeInfoUpdateRequest;
 import org.devcourse.resumeme.business.user.controller.mentee.dto.MenteeRegisterInfoRequest;
 import org.devcourse.resumeme.business.user.domain.mentee.Mentee;
 import org.devcourse.resumeme.business.user.service.mentee.MenteeService;
 import org.devcourse.resumeme.common.response.IdResponse;
-import org.devcourse.resumeme.business.user.controller.mentee.dto.MenteeInfoResponse;
 import org.devcourse.resumeme.global.auth.model.jwt.Claims;
 import org.devcourse.resumeme.global.auth.model.login.OAuth2TempInfo;
 import org.devcourse.resumeme.global.auth.service.jwt.JwtService;
 import org.devcourse.resumeme.global.auth.service.login.OAuth2InfoRedisService;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -38,15 +39,14 @@ public class MenteeController {
         log.debug("registerInfoRequest.cacheKey = {}", registerInfoRequest.cacheKey());
         OAuth2TempInfo oAuth2TempInfo = oAuth2InfoRedisService.getOne(registerInfoRequest.cacheKey());
 
-        String refreshToken = jwtService.createRefreshToken();
-        Mentee mentee = registerInfoRequest.toEntity(oAuth2TempInfo, refreshToken);
+        Mentee mentee = registerInfoRequest.toEntity(oAuth2TempInfo);
         Mentee savedMentee = menteeService.create(mentee);
-        String accessToken = jwtService.createAccessToken(Claims.of(savedMentee));
+        HttpHeaders tokens = jwtService.createTokens(Claims.of(savedMentee));
+        menteeService.updateRefreshToken(savedMentee.getId(), tokens.getFirst("Refresh-Token"));
         oAuth2InfoRedisService.delete(oAuth2TempInfo.getId());
 
         return ResponseEntity.status(200)
-                .header("access", accessToken)
-                .header("refresh", refreshToken)
+                .headers(tokens)
                 .build();
     }
 

--- a/src/main/java/org/devcourse/resumeme/business/user/controller/mentee/MenteeController.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/controller/mentee/MenteeController.java
@@ -22,6 +22,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static org.devcourse.resumeme.global.auth.service.jwt.Token.*;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -46,8 +48,8 @@ public class MenteeController {
         oAuth2InfoRedisService.delete(oAuth2TempInfo.getId());
 
         return ResponseEntity.status(200)
-                .header(token.getAccessTokenName(), token.accessToken())
-                .header(token.getRefreshTokenName(), token.refreshToken())
+                .header(ACCESS_TOKEN_NAME, token.accessToken())
+                .header(REFRESH_TOKEN_NAME, token.refreshToken())
                 .build();
     }
 

--- a/src/main/java/org/devcourse/resumeme/business/user/controller/mentee/dto/MenteeRegisterInfoRequest.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/controller/mentee/dto/MenteeRegisterInfoRequest.java
@@ -10,7 +10,7 @@ import java.util.Set;
 
 public record MenteeRegisterInfoRequest(String cacheKey, RequiredInfoRequest requiredInfo, Set<String> interestedPositions, Set<String> interestedFields, String introduce) {
 
-    public Mentee toEntity(OAuth2TempInfo oAuth2TempInfo, String refreshToken) {
+    public Mentee toEntity(OAuth2TempInfo oAuth2TempInfo) {
         return Mentee.builder()
                 .email(oAuth2TempInfo.getEmail())
                 .provider(Provider.valueOf(oAuth2TempInfo.getProvider().toUpperCase()))
@@ -18,7 +18,6 @@ public record MenteeRegisterInfoRequest(String cacheKey, RequiredInfoRequest req
                 .requiredInfo(
                         new RequiredInfo(requiredInfo.realName(), requiredInfo.nickname(), requiredInfo.phoneNumber(), requiredInfo.role())
                 )
-                .refreshToken(refreshToken)
                 .introduce(introduce)
                 .interestedPositions(interestedPositions)
                 .interestedFields(interestedFields)

--- a/src/main/java/org/devcourse/resumeme/business/user/controller/mentor/MentorController.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/controller/mentor/MentorController.java
@@ -11,8 +11,8 @@ import org.devcourse.resumeme.common.response.IdResponse;
 import org.devcourse.resumeme.global.auth.model.jwt.Claims;
 import org.devcourse.resumeme.global.auth.model.login.OAuth2TempInfo;
 import org.devcourse.resumeme.global.auth.service.jwt.JwtService;
+import org.devcourse.resumeme.global.auth.service.jwt.Token;
 import org.devcourse.resumeme.global.auth.service.login.OAuth2InfoRedisService;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -41,12 +41,13 @@ public class MentorController {
 
         Mentor mentor = registerInfoRequest.toEntity(oAuth2TempInfo);
         Mentor savedMentor = mentorService.create(mentor);
-        HttpHeaders tokens = jwtService.createTokens(Claims.of(savedMentor));
-        mentorService.updateRefreshToken(savedMentor.getId(), tokens.getFirst("Refresh-Token"));
+        Token tokens = jwtService.createTokens(Claims.of(savedMentor));
+        mentorService.updateRefreshToken(savedMentor.getId(), tokens.refreshToken());
         oAuth2InfoRedisService.delete(oAuth2TempInfo.getId());
 
         return ResponseEntity.status(200)
-                .headers(tokens)
+                .header(tokens.getAccessTokenName(),tokens.accessToken())
+                .header(tokens.getRefreshTokenName(),tokens.refreshToken())
                 .build();
     }
 

--- a/src/main/java/org/devcourse/resumeme/business/user/controller/mentor/MentorController.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/controller/mentor/MentorController.java
@@ -22,6 +22,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static org.devcourse.resumeme.global.auth.service.jwt.Token.*;
+
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/mentors")
@@ -41,13 +43,13 @@ public class MentorController {
 
         Mentor mentor = registerInfoRequest.toEntity(oAuth2TempInfo);
         Mentor savedMentor = mentorService.create(mentor);
-        Token tokens = jwtService.createTokens(Claims.of(savedMentor));
-        mentorService.updateRefreshToken(savedMentor.getId(), tokens.refreshToken());
+        Token token = jwtService.createTokens(Claims.of(savedMentor));
+        mentorService.updateRefreshToken(savedMentor.getId(), token.refreshToken());
         oAuth2InfoRedisService.delete(oAuth2TempInfo.getId());
 
         return ResponseEntity.status(200)
-                .header(tokens.getAccessTokenName(),tokens.accessToken())
-                .header(tokens.getRefreshTokenName(),tokens.refreshToken())
+                .header(ACCESS_TOKEN_NAME, token.accessToken())
+                .header(REFRESH_TOKEN_NAME, token.refreshToken())
                 .build();
     }
 

--- a/src/main/java/org/devcourse/resumeme/business/user/controller/mentor/dto/MentorRegisterInfoRequest.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/controller/mentor/dto/MentorRegisterInfoRequest.java
@@ -1,16 +1,16 @@
 package org.devcourse.resumeme.business.user.controller.mentor.dto;
 
+import org.devcourse.resumeme.business.user.controller.dto.RequiredInfoRequest;
 import org.devcourse.resumeme.business.user.domain.Provider;
 import org.devcourse.resumeme.business.user.domain.mentee.RequiredInfo;
 import org.devcourse.resumeme.business.user.domain.mentor.Mentor;
-import org.devcourse.resumeme.business.user.controller.dto.RequiredInfoRequest;
 import org.devcourse.resumeme.global.auth.model.login.OAuth2TempInfo;
 
 import java.util.Set;
 
 public record MentorRegisterInfoRequest(String cacheKey, RequiredInfoRequest requiredInfo, Set<String> experiencedPositions, String careerContent, int careerYear, String introduce) {
 
-    public Mentor toEntity(OAuth2TempInfo oAuth2TempInfo, String refreshToken) {
+    public Mentor toEntity(OAuth2TempInfo oAuth2TempInfo) {
         return Mentor.builder()
                 .email(oAuth2TempInfo.getEmail())
                 .provider(Provider.valueOf(oAuth2TempInfo.getProvider().toUpperCase()))
@@ -18,7 +18,6 @@ public record MentorRegisterInfoRequest(String cacheKey, RequiredInfoRequest req
                 .requiredInfo(
                         new RequiredInfo(requiredInfo().realName(), requiredInfo().nickname(), requiredInfo().phoneNumber(), requiredInfo().role())
                 )
-                .refreshToken(refreshToken)
                 .introduce(introduce)
                 .experiencedPositions(experiencedPositions)
                 .careerContent(careerContent)

--- a/src/main/java/org/devcourse/resumeme/business/user/domain/mentee/Mentee.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/domain/mentee/Mentee.java
@@ -72,7 +72,7 @@ public class Mentee extends BaseEntity {
 
     @Builder
     public Mentee(Long id,String email, Provider provider, String imageUrl, RequiredInfo requiredInfo, String refreshToken, Set<String> interestedPositions, Set<String> interestedFields, String introduce) {
-        validateInputs(email, provider, imageUrl, requiredInfo, refreshToken);
+        validateInputs(email, provider, imageUrl, requiredInfo);
         this.id = id;
         this.email = email;
         this.provider = provider;
@@ -84,13 +84,12 @@ public class Mentee extends BaseEntity {
         this.introduce = introduce;
     }
 
-    private void validateInputs(String email, Provider provider, String imageUrl, RequiredInfo requiredInfo, String refreshToken) {
+    private void validateInputs(String email, Provider provider, String imageUrl, RequiredInfo requiredInfo) {
         check(email == null || email.isBlank() || !email.matches(EMAIL_REGEX), "INVALID_EMAIL", "이메일이 유효하지 않습니다.");
         check(provider == null, NO_EMPTY_VALUE);
         check(imageUrl == null || imageUrl.isBlank(), NO_EMPTY_VALUE);
         check(requiredInfo == null, NO_EMPTY_VALUE);
         check(!Role.ROLE_MENTEE.equals(requiredInfo.getRole()), ROLE_NOT_ALLOWED);
-        check(refreshToken == null || refreshToken.isBlank(), NO_EMPTY_VALUE);
     }
 
     public void updateInfos(MenteeInfoUpdateRequest updateRequest) {

--- a/src/main/java/org/devcourse/resumeme/business/user/domain/mentor/Mentor.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/domain/mentor/Mentor.java
@@ -73,7 +73,7 @@ public class Mentor extends BaseEntity {
 
     @Builder
     public Mentor(Long id, String email, Provider provider, String imageUrl, RequiredInfo requiredInfo, String refreshToken, Set<String> experiencedPositions, String careerContent, int careerYear, String introduce) {
-        validateInputs(email, provider, imageUrl, requiredInfo, refreshToken, experiencedPositions, careerContent, careerYear, introduce);
+        validateInputs(email, provider, imageUrl, requiredInfo, experiencedPositions, careerContent, careerYear, introduce);
         this.id = id;
         this.email = email;
         this.provider = provider;
@@ -86,13 +86,12 @@ public class Mentor extends BaseEntity {
         this.introduce = introduce;
     }
 
-    private void validateInputs(String email, Provider provider, String imageUrl, RequiredInfo requiredInfo, String refreshToken, Set<String> experiencedPositions, String careerContent, int careerYear, String introduce) {
+    private void validateInputs(String email, Provider provider, String imageUrl, RequiredInfo requiredInfo, Set<String> experiencedPositions, String careerContent, int careerYear, String introduce) {
         check(email == null || email.isBlank() || !email.matches(EMAIL_REGEX), "INVALID_EMAIL", "이메일이 유효하지 않습니다.");
         check(provider == null, NO_EMPTY_VALUE);
         check(imageUrl == null || imageUrl.isBlank(), NO_EMPTY_VALUE);
         check(requiredInfo == null, NO_EMPTY_VALUE);
         check(Role.ROLE_MENTEE.equals(requiredInfo.getRole()) || Role.ROLE_ADMIN.equals(requiredInfo.getRole()), ROLE_NOT_ALLOWED);
-        check(refreshToken == null || refreshToken.isBlank(), NO_EMPTY_VALUE);
         check(experiencedPositions == null || experiencedPositions.size() == 0, NO_EMPTY_VALUE);
         check(careerContent == null || careerContent.isBlank(), NO_EMPTY_VALUE);
         check(careerYear < 1 || careerYear > 80, "NUMBER_NOT_ALLOWED", "경력 연차가 올바르지 않습니다.");

--- a/src/main/java/org/devcourse/resumeme/global/auth/filter/handler/OAuth2FailureHandler.java
+++ b/src/main/java/org/devcourse/resumeme/global/auth/filter/handler/OAuth2FailureHandler.java
@@ -1,6 +1,5 @@
 package org.devcourse.resumeme.global.auth.filter.handler;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -10,21 +9,18 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 
-import java.io.IOException;
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2FailureHandler implements AuthenticationFailureHandler {
 
     @Override
-    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) {
         String cacheKey = exception.getMessage();
 
         response.setCharacterEncoding("UTF-8");
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.addHeader("cacheKey", cacheKey);
-        response.addHeader("location", "/api/v1/user-info-form");
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/global/auth/service/jwt/JwtService.java
+++ b/src/main/java/org/devcourse/resumeme/global/auth/service/jwt/JwtService.java
@@ -8,9 +8,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.devcourse.resumeme.global.auth.model.jwt.Claims;
-import org.springframework.http.HttpHeaders;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 
 import java.util.Date;
 import java.util.Map;
@@ -105,12 +102,10 @@ public class JwtService {
         return refreshTokenSaved.equals(refreshToken);
     }
 
-    public HttpHeaders createTokens(Claims claims) {
-        MultiValueMap<String, String> tokens = new LinkedMultiValueMap<>();
-        tokens.add(ACCESS_TOKEN_NAME, createAccessToken(new Claims(claims.id(), claims.role(), new Date())));
-        tokens.add(REFRESH_TOKEN_NAME, createRefreshToken());
+    public Token createTokens(Claims claims) {
+        Claims claimsForIssueToken = new Claims(claims.id(), claims.role(), new Date());
 
-        return new HttpHeaders(tokens);
+        return new Token(createAccessToken(claimsForIssueToken), createRefreshToken());
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/global/auth/service/jwt/JwtService.java
+++ b/src/main/java/org/devcourse/resumeme/global/auth/service/jwt/JwtService.java
@@ -8,6 +8,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.devcourse.resumeme.global.auth.model.jwt.Claims;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import java.util.Date;
 import java.util.Map;
@@ -17,9 +20,9 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class JwtService {
 
-    private static final String ACCESS_TOKEN_NAME = "access";
+    private static final String ACCESS_TOKEN_NAME = "Authorization";
 
-    private static final String REFRESH_TOKEN_NAME = "refresh";
+    private static final String REFRESH_TOKEN_NAME = "Refresh-Token";
 
     private static final int ACCESS_TOKEN_EXP = 3600 * 1000;
 
@@ -102,11 +105,12 @@ public class JwtService {
         return refreshTokenSaved.equals(refreshToken);
     }
 
-    public Map<String, String> createAndSendNewTokens(Claims claims, HttpServletResponse response) {
-        String accessToken = createAccessToken(new Claims(claims.id(), claims.role(), new Date()));
-        String refreshToken = createRefreshToken();
-        sendAccessAndRefreshToken(response, accessToken, refreshToken);
-        return Map.of("access", accessToken, "refresh", refreshToken);
+    public HttpHeaders createTokens(Claims claims) {
+        MultiValueMap<String, String> tokens = new LinkedMultiValueMap<>();
+        tokens.add(ACCESS_TOKEN_NAME, createAccessToken(new Claims(claims.id(), claims.role(), new Date())));
+        tokens.add(REFRESH_TOKEN_NAME, createRefreshToken());
+
+        return new HttpHeaders(tokens);
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/global/auth/service/jwt/Token.java
+++ b/src/main/java/org/devcourse/resumeme/global/auth/service/jwt/Token.java
@@ -4,14 +4,6 @@ public record Token(String accessToken, String refreshToken) {
 
     public static final String ACCESS_TOKEN_NAME = "Authorization";
 
-    static final String REFRESH_TOKEN_NAME = "Refresh-Token";
-
-    public String getAccessTokenName() {
-        return ACCESS_TOKEN_NAME;
-    }
-
-    public String getRefreshTokenName() {
-        return REFRESH_TOKEN_NAME;
-    }
+    public static final String REFRESH_TOKEN_NAME = "Refresh-Token";
 
 }

--- a/src/main/java/org/devcourse/resumeme/global/auth/service/jwt/Token.java
+++ b/src/main/java/org/devcourse/resumeme/global/auth/service/jwt/Token.java
@@ -1,0 +1,17 @@
+package org.devcourse.resumeme.global.auth.service.jwt;
+
+public record Token(String accessToken, String refreshToken) {
+
+    public static final String ACCESS_TOKEN_NAME = "Authorization";
+
+    static final String REFRESH_TOKEN_NAME = "Refresh-Token";
+
+    public String getAccessTokenName() {
+        return ACCESS_TOKEN_NAME;
+    }
+
+    public String getRefreshTokenName() {
+        return REFRESH_TOKEN_NAME;
+    }
+
+}

--- a/src/test/java/org/devcourse/resumeme/business/user/controller/mentee/MenteeControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/business/user/controller/mentee/MenteeControllerTest.java
@@ -10,9 +10,9 @@ import org.devcourse.resumeme.common.ControllerUnitTest;
 import org.devcourse.resumeme.common.support.WithMockCustomUser;
 import org.devcourse.resumeme.global.auth.model.jwt.Claims;
 import org.devcourse.resumeme.global.auth.model.login.OAuth2TempInfo;
+import org.devcourse.resumeme.global.auth.service.jwt.Token;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -23,6 +23,7 @@ import static org.devcourse.resumeme.common.util.ApiDocumentUtils.getDocumentReq
 import static org.devcourse.resumeme.common.util.ApiDocumentUtils.getDocumentResponse;
 import static org.devcourse.resumeme.common.util.DocumentLinkGenerator.DocUrl.ROLE;
 import static org.devcourse.resumeme.common.util.DocumentLinkGenerator.generateLinkCode;
+import static org.devcourse.resumeme.global.auth.service.jwt.Token.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
@@ -52,11 +53,7 @@ class MenteeControllerTest extends ControllerUnitTest {
 
     private Mentee mentee;
 
-    private HttpHeaders headers = new HttpHeaders();
-
-    private final String ACCESS_TOKEN_NAME = "Authorization";
-
-    private final String REFRESH_TOKEN_NAME = "Refresh-Token";
+    private Token token;
 
     @BeforeEach
     void setUp() {
@@ -64,8 +61,7 @@ class MenteeControllerTest extends ControllerUnitTest {
         menteeRegisterInfoRequest = new MenteeRegisterInfoRequest("cacheKey", requiredInfoRequest, Set.of("FRONT", "BACK"), Set.of("RETAIL", "MANUFACTURE"), "안녕하세요 백둥이 4기 머쓱이입니다.");
         oAuth2TempInfo = new OAuth2TempInfo(null, "KAKAO", "지롱", "backdong1@kakao.com", "image.png");
         mentee = menteeRegisterInfoRequest.toEntity(oAuth2TempInfo);
-        headers.set(ACCESS_TOKEN_NAME, "IssuedAccessToken");
-        headers.set(REFRESH_TOKEN_NAME, "IssuedRefreshToken");
+        token = new Token("issuedAccessToken", "issuedRefreshToken");
     }
 
     @Test
@@ -85,7 +81,7 @@ class MenteeControllerTest extends ControllerUnitTest {
 
         given(oAuth2InfoRedisService.getOne(any())).willReturn(oAuth2TempInfo);
         given(menteeService.create(any(Mentee.class))).willReturn(savedMentee);
-        given(jwtService.createTokens(any(Claims.class))).willReturn(headers);
+        given(jwtService.createTokens(any(Claims.class))).willReturn(token);
 
         // when
         ResultActions result = mvc.perform(post("/api/v1/mentees")

--- a/src/test/java/org/devcourse/resumeme/business/user/controller/mentor/MentorControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/business/user/controller/mentor/MentorControllerTest.java
@@ -1,19 +1,20 @@
 package org.devcourse.resumeme.business.user.controller.mentor;
 
-import org.devcourse.resumeme.common.ControllerUnitTest;
+import org.devcourse.resumeme.business.user.controller.dto.RequiredInfoRequest;
 import org.devcourse.resumeme.business.user.controller.mentee.dto.MenteeInfoUpdateRequest;
 import org.devcourse.resumeme.business.user.controller.mentor.dto.MentorInfoUpdateRequest;
 import org.devcourse.resumeme.business.user.controller.mentor.dto.MentorRegisterInfoRequest;
-import org.devcourse.resumeme.business.user.controller.dto.RequiredInfoRequest;
-import org.devcourse.resumeme.business.user.domain.mentee.RequiredInfo;
-import org.devcourse.resumeme.business.user.domain.mentor.Mentor;
 import org.devcourse.resumeme.business.user.domain.Provider;
 import org.devcourse.resumeme.business.user.domain.Role;
+import org.devcourse.resumeme.business.user.domain.mentee.RequiredInfo;
+import org.devcourse.resumeme.business.user.domain.mentor.Mentor;
+import org.devcourse.resumeme.common.ControllerUnitTest;
+import org.devcourse.resumeme.common.support.WithMockCustomUser;
 import org.devcourse.resumeme.global.auth.model.jwt.Claims;
 import org.devcourse.resumeme.global.auth.model.login.OAuth2TempInfo;
-import org.devcourse.resumeme.common.support.WithMockCustomUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -21,10 +22,10 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.INTEGER;
 import static org.assertj.core.api.Assertions.MAP;
-import static org.devcourse.resumeme.common.util.DocumentLinkGenerator.DocUrl.ROLE;
-import static org.devcourse.resumeme.common.util.DocumentLinkGenerator.generateLinkCode;
 import static org.devcourse.resumeme.common.util.ApiDocumentUtils.getDocumentRequest;
 import static org.devcourse.resumeme.common.util.ApiDocumentUtils.getDocumentResponse;
+import static org.devcourse.resumeme.common.util.DocumentLinkGenerator.DocUrl.ROLE;
+import static org.devcourse.resumeme.common.util.DocumentLinkGenerator.generateLinkCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
@@ -56,13 +57,20 @@ class MentorControllerTest extends ControllerUnitTest {
 
     private Mentor savedMentor;
 
+    private HttpHeaders headers = new HttpHeaders();
+
+    private final String ACCESS_TOKEN_NAME = "Authorization";
+
+    private final String REFRESH_TOKEN_NAME = "Refresh-Token";
+
     @BeforeEach
     void setUp() {
         requiredInfoRequest = new RequiredInfoRequest("nickname", "realName", "01034548443", Role.ROLE_PENDING);
         mentorRegisterInfoRequest = new MentorRegisterInfoRequest("cacheKey", requiredInfoRequest, Set.of("FRONT", "BACK"), "A회사 00팀, B회사 xx팀", 3, "안녕하세요 멘토가 되고싶어요.");
         oAuth2TempInfo = new OAuth2TempInfo(null, "GOOGLE", "지롱", "devcoco@naver.com", "image.png");
-
-        mentor = mentorRegisterInfoRequest.toEntity(oAuth2TempInfo, "refreshTokenRecentlyIssued");
+        mentor = mentorRegisterInfoRequest.toEntity(oAuth2TempInfo);
+        headers.set(ACCESS_TOKEN_NAME, "IssuedAccessToken");
+        headers.set(REFRESH_TOKEN_NAME, "IssuedRefreshToken");
     }
 
     @Test
@@ -82,8 +90,7 @@ class MentorControllerTest extends ControllerUnitTest {
 
         given(oAuth2InfoRedisService.getOne(any())).willReturn((oAuth2TempInfo));
         given(mentorService.create(any(Mentor.class))).willReturn(savedMentor);
-        given(jwtService.createAccessToken(any(Claims.class))).willReturn("accessTokenRecentlyIssued");
-        given(jwtService.createRefreshToken()).willReturn("refreshTokenRecentlyIssued");
+        given(jwtService.createTokens(any(Claims.class))).willReturn(headers);
 
         // when
         ResultActions result = mvc.perform(post("/api/v1/mentors")
@@ -93,8 +100,8 @@ class MentorControllerTest extends ControllerUnitTest {
         // then
         result
                 .andExpect(status().isOk())
-                .andExpect(header().exists("access"))
-                .andExpect(header().exists("refresh"))
+                .andExpect(header().exists(ACCESS_TOKEN_NAME))
+                .andExpect(header().exists(REFRESH_TOKEN_NAME))
                 .andDo(
                         document("user/mentor/create",
                                 getDocumentRequest(),
@@ -111,8 +118,8 @@ class MentorControllerTest extends ControllerUnitTest {
                                         fieldWithPath("introduce").type(STRING).description("자기소개")
                                 ),
                                 responseHeaders(
-                                        headerWithName("access").description("액세스 토큰"),
-                                        headerWithName("refresh").description("리프레시 토큰")
+                                        headerWithName(ACCESS_TOKEN_NAME).description("액세스 토큰"),
+                                        headerWithName(REFRESH_TOKEN_NAME).description("리프레시 토큰")
                                 )
                         )
                 );

--- a/src/test/java/org/devcourse/resumeme/global/auth/filter/OAuthTokenResponseFilterTest.java
+++ b/src/test/java/org/devcourse/resumeme/global/auth/filter/OAuthTokenResponseFilterTest.java
@@ -1,10 +1,10 @@
 package org.devcourse.resumeme.global.auth.filter;
 
-import org.devcourse.resumeme.common.ControllerUnitTest;
 import org.devcourse.resumeme.business.user.domain.Role;
+import org.devcourse.resumeme.common.ControllerUnitTest;
+import org.devcourse.resumeme.global.auth.filter.resolver.OAuthAuthenticationToken;
 import org.devcourse.resumeme.global.auth.model.UserCommonInfo;
 import org.devcourse.resumeme.global.auth.model.login.OAuth2CustomUser;
-import org.devcourse.resumeme.global.auth.filter.resolver.OAuthAuthenticationToken;
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
@@ -15,10 +15,10 @@ import org.springframework.test.web.servlet.ResultActions;
 import java.util.List;
 import java.util.Map;
 
-import static org.devcourse.resumeme.common.util.DocumentLinkGenerator.DocUrl.PROVIDER;
-import static org.devcourse.resumeme.common.util.DocumentLinkGenerator.generateLinkCode;
 import static org.devcourse.resumeme.common.util.ApiDocumentUtils.getDocumentRequest;
 import static org.devcourse.resumeme.common.util.ApiDocumentUtils.getDocumentResponse;
+import static org.devcourse.resumeme.common.util.DocumentLinkGenerator.DocUrl.PROVIDER;
+import static org.devcourse.resumeme.common.util.DocumentLinkGenerator.generateLinkCode;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
@@ -30,6 +30,10 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class OAuthTokenResponseFilterTest extends ControllerUnitTest {
+
+    private final String ACCESS_TOKEN_NAME = "Authorization";
+
+    private final String REFRESH_TOKEN_NAME = "Refresh-Token";
 
     @Test
     void 사용자는_로그인을_oauth를_통해_할수있다() throws Exception {
@@ -57,8 +61,8 @@ class OAuthTokenResponseFilterTest extends ControllerUnitTest {
                                         fieldWithPath("code").type(JsonFieldType.STRING).description("oauth 서버로 부터 받은 인가 코드")
                                 ),
                                 responseHeaders(
-                                        headerWithName("access").description("액세스 토큰"),
-                                        headerWithName("refresh").description("리프레시 토큰")
+                                        headerWithName(ACCESS_TOKEN_NAME).description("액세스 토큰"),
+                                        headerWithName(REFRESH_TOKEN_NAME).description("리프레시 토큰")
                                 )
                         )
                 );

--- a/src/test/java/org/devcourse/resumeme/global/auth/filter/OAuthTokenResponseFilterTest.java
+++ b/src/test/java/org/devcourse/resumeme/global/auth/filter/OAuthTokenResponseFilterTest.java
@@ -94,8 +94,7 @@ class OAuthTokenResponseFilterTest extends ControllerUnitTest {
                                         fieldWithPath("code").type(JsonFieldType.STRING).description("oauth 서버로 부터 받은 인가 코드")
                                 ),
                                 responseHeaders(
-                                        headerWithName("cacheKey").description("oauth 서버로 부터 받은 사용자 정보 임시 저장 키"),
-                                        headerWithName("location").description("필수 정보 받은 후 회원가입 redirect endpoint")
+                                        headerWithName("cacheKey").description("oauth 서버로 부터 받은 사용자 정보 임시 저장 키")
                                 )
                         )
                 );

--- a/src/test/java/org/devcourse/resumeme/global/auth/service/jwt/JwtServiceTest.java
+++ b/src/test/java/org/devcourse/resumeme/global/auth/service/jwt/JwtServiceTest.java
@@ -24,6 +24,10 @@ class JwtServiceTest {
 
     private String refreshToken;
 
+    private final String ACCESS_TOKEN_NAME = "Authorization";
+
+    private final String REFRESH_TOKEN_NAME = "Refresh-Token";
+
     @BeforeEach
     void setUp() {
         Claims claims = new Claims(1L, ROLE_MENTEE.name(), new Date());
@@ -43,7 +47,7 @@ class JwtServiceTest {
     @Test
     void 액세스_토큰을_추출하는데_성공한다() {
         MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addHeader("access", accessToken);
+        request.addHeader(ACCESS_TOKEN_NAME, accessToken);
         String extractedAccessToken = jwtService.extractAccessToken(request).get();
         jwtService.compareTokens(accessToken, extractedAccessToken);
     }
@@ -52,7 +56,7 @@ class JwtServiceTest {
     void 리프레시_토큰을_추출하는데_성공한다() {
         refreshToken = jwtService.createRefreshToken();
         MockHttpServletRequest request = new MockHttpServletRequest();
-        request.addHeader("refresh", refreshToken);
+        request.addHeader(REFRESH_TOKEN_NAME, refreshToken);
         String extractedRefreshToken = jwtService.extractRefreshToken(request).get();
         jwtService.compareTokens(refreshToken, extractedRefreshToken);
     }


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
- 토큰 헤더 네임 수정 : "access" -> "Authorization" , "refresh" -> "Refresh-Token"
- 멘토 / 멘티 refreshToken 값 null 허용

## CC. 리뷰어
- 테스트 변경사항은 토큰 이름뿐이라서 안보셔도 됩니다!

## 테스트 설명


## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
