### PR TITLE
fix: 멘토/멘티 조회 response role 값 수정 및 삭제

### DIFF
--- a/src/main/java/org/devcourse/resumeme/business/user/controller/dto/UserInfoResponse.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/controller/dto/UserInfoResponse.java
@@ -1,5 +1,6 @@
 package org.devcourse.resumeme.business.user.controller.dto;
 
+import org.devcourse.resumeme.business.user.domain.Role;
 import org.devcourse.resumeme.business.user.domain.mentee.Mentee;
 import org.devcourse.resumeme.business.user.domain.mentor.Mentor;
 
@@ -11,7 +12,7 @@ public record UserInfoResponse(String imageUrl, String realName, String nickname
                                Set<String> interestedFields, String careerContent, int careerYear, String introduce) {
 
     public UserInfoResponse(Mentor mentor) {
-        this(mentor.getImageUrl(), mentor.getRequiredInfo().getRealName(), mentor.getRequiredInfo().getNickname(), mentor.getRequiredInfo().getPhoneNumber(), "mentor", getExperiencedPositions(mentor), null, null, mentor.getCareerContent(), mentor.getCareerYear(), mentor.getIntroduce());
+        this(mentor.getImageUrl(), mentor.getRequiredInfo().getRealName(), mentor.getRequiredInfo().getNickname(), mentor.getRequiredInfo().getPhoneNumber(), mentor.getRequiredInfo().getRole().equals(Role.ROLE_MENTOR) ? "mentor" : "pending", getExperiencedPositions(mentor), null, null, mentor.getCareerContent(), mentor.getCareerYear(), mentor.getIntroduce());
     }
 
     public UserInfoResponse(Mentee mentee) {

--- a/src/main/java/org/devcourse/resumeme/business/user/controller/dto/UserInfoResponse.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/controller/dto/UserInfoResponse.java
@@ -11,11 +11,11 @@ public record UserInfoResponse(String imageUrl, String realName, String nickname
                                Set<String> interestedFields, String careerContent, int careerYear, String introduce) {
 
     public UserInfoResponse(Mentor mentor) {
-        this(mentor.getImageUrl(), mentor.getRequiredInfo().getRealName(), mentor.getRequiredInfo().getNickname(), mentor.getRequiredInfo().getPhoneNumber(), mentor.getRequiredInfo().getRole().getDescription(), getExperiencedPositions(mentor), null, null, mentor.getCareerContent(), mentor.getCareerYear(), mentor.getIntroduce());
+        this(mentor.getImageUrl(), mentor.getRequiredInfo().getRealName(), mentor.getRequiredInfo().getNickname(), mentor.getRequiredInfo().getPhoneNumber(), mentor.getRoleName(), getExperiencedPositions(mentor), null, null, mentor.getCareerContent(), mentor.getCareerYear(), mentor.getIntroduce());
     }
 
     public UserInfoResponse(Mentee mentee) {
-        this(mentee.getImageUrl(), mentee.getRequiredInfo().getRealName(), mentee.getRequiredInfo().getNickname(), mentee.getRequiredInfo().getPhoneNumber(), "mentee", null, getInterestedPositions(mentee), getInterestedFields(mentee), null, 0, mentee.getIntroduce());
+        this(mentee.getImageUrl(), mentee.getRequiredInfo().getRealName(), mentee.getRequiredInfo().getNickname(), mentee.getRequiredInfo().getPhoneNumber(), mentee.getRoleName(), null, getInterestedPositions(mentee), getInterestedFields(mentee), null, 0, mentee.getIntroduce());
     }
 
     private static Set<String> getExperiencedPositions(Mentor mentor) {

--- a/src/main/java/org/devcourse/resumeme/business/user/controller/dto/UserInfoResponse.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/controller/dto/UserInfoResponse.java
@@ -1,6 +1,5 @@
 package org.devcourse.resumeme.business.user.controller.dto;
 
-import org.devcourse.resumeme.business.user.domain.Role;
 import org.devcourse.resumeme.business.user.domain.mentee.Mentee;
 import org.devcourse.resumeme.business.user.domain.mentor.Mentor;
 
@@ -12,7 +11,7 @@ public record UserInfoResponse(String imageUrl, String realName, String nickname
                                Set<String> interestedFields, String careerContent, int careerYear, String introduce) {
 
     public UserInfoResponse(Mentor mentor) {
-        this(mentor.getImageUrl(), mentor.getRequiredInfo().getRealName(), mentor.getRequiredInfo().getNickname(), mentor.getRequiredInfo().getPhoneNumber(), mentor.getRequiredInfo().getRole().equals(Role.ROLE_MENTOR) ? "mentor" : "pending", getExperiencedPositions(mentor), null, null, mentor.getCareerContent(), mentor.getCareerYear(), mentor.getIntroduce());
+        this(mentor.getImageUrl(), mentor.getRequiredInfo().getRealName(), mentor.getRequiredInfo().getNickname(), mentor.getRequiredInfo().getPhoneNumber(), mentor.getRequiredInfo().getRole().getDescription(), getExperiencedPositions(mentor), null, null, mentor.getCareerContent(), mentor.getCareerYear(), mentor.getIntroduce());
     }
 
     public UserInfoResponse(Mentee mentee) {

--- a/src/main/java/org/devcourse/resumeme/business/user/controller/mentee/dto/MenteeInfoResponse.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/controller/mentee/dto/MenteeInfoResponse.java
@@ -5,11 +5,11 @@ import org.devcourse.resumeme.business.user.domain.mentee.Mentee;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public record MenteeInfoResponse(String imageUrl, String realName, String nickname, String phoneNumber, String role, Set<String> interestedPositions,
+public record MenteeInfoResponse(String imageUrl, String realName, String nickname, String phoneNumber, Set<String> interestedPositions,
                              Set<String> interestedFields, String introduce) {
 
     public MenteeInfoResponse(Mentee mentee) {
-        this(mentee.getImageUrl(), mentee.getRequiredInfo().getRealName(), mentee.getRequiredInfo().getNickname(), mentee.getRequiredInfo().getPhoneNumber(), mentee.getRequiredInfo().getRole().name(),
+        this(mentee.getImageUrl(), mentee.getRequiredInfo().getRealName(), mentee.getRequiredInfo().getNickname(), mentee.getRequiredInfo().getPhoneNumber(),
                 getInterestedPositions(mentee),
                 getInterestedFields(mentee),
                 mentee.getIntroduce());

--- a/src/main/java/org/devcourse/resumeme/business/user/controller/mentor/dto/MentorInfoResponse.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/controller/mentor/dto/MentorInfoResponse.java
@@ -5,10 +5,10 @@ import org.devcourse.resumeme.business.user.domain.mentor.Mentor;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public record MentorInfoResponse(String imageUrl, String nickname, String role, Set<String> experiencedPositions, String careerContent, int careerYear, String introduce) {
+public record MentorInfoResponse(String imageUrl, String nickname, Set<String> experiencedPositions, String careerContent, int careerYear, String introduce) {
 
     public MentorInfoResponse(Mentor mentor) {
-        this(mentor.getImageUrl(), mentor.getRequiredInfo().getNickname(), mentor.getRequiredInfo().getRole().name(), getExperiencedPositions(mentor), mentor.getIntroduce(), mentor.getCareerYear(), mentor.getIntroduce());
+        this(mentor.getImageUrl(), mentor.getRequiredInfo().getNickname(), getExperiencedPositions(mentor), mentor.getIntroduce(), mentor.getCareerYear(), mentor.getIntroduce());
     }
 
     private static Set<String> getExperiencedPositions(Mentor mentor) {

--- a/src/main/java/org/devcourse/resumeme/business/user/domain/Role.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/domain/Role.java
@@ -11,11 +11,12 @@ public enum Role implements DocsEnumType {
     ROLE_MENTOR("mentor"), // 멘토 승인 완료
     ROLE_ADMIN("admin");
 
-    private final String role;
+    private final String roleName;
 
-    Role(String role) {
-        this.role = role;
+    Role(String roleName) {
+        this.roleName = roleName;
     }
+
 
     public static Role of(String roleName) {
         return Arrays.stream(values())
@@ -31,8 +32,9 @@ public enum Role implements DocsEnumType {
 
     @Override
     public String getDescription() {
-        return role;
+        return roleName;
     }
 
+    public String getRoleName() {return roleName;}
 
 }

--- a/src/main/java/org/devcourse/resumeme/business/user/domain/mentee/Mentee.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/domain/mentee/Mentee.java
@@ -114,4 +114,8 @@ public class Mentee extends BaseEntity {
         this.getInterestedFields().clear();
     }
 
+    public String getRoleName() {
+        return requiredInfo.getRealName();
+    }
+
 }

--- a/src/main/java/org/devcourse/resumeme/business/user/domain/mentor/Mentor.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/domain/mentor/Mentor.java
@@ -128,4 +128,8 @@ public class Mentor extends BaseEntity {
         this.getExperiencedPositions().clear();
     }
 
+    public String getRoleName() {
+        return requiredInfo.getRealName();
+    }
+
 }

--- a/src/test/java/org/devcourse/resumeme/business/user/controller/mentee/MenteeControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/business/user/controller/mentee/MenteeControllerTest.java
@@ -156,7 +156,6 @@ class MenteeControllerTest extends ControllerUnitTest {
                                         fieldWithPath("realName").type(STRING).description("실명"),
                                         fieldWithPath("nickname").type(STRING).description("닉네임"),
                                         fieldWithPath("phoneNumber").type(STRING).description("전화번호"),
-                                        fieldWithPath("role").type(STRING).description(generateLinkCode(ROLE)),
                                         fieldWithPath("interestedPositions").type(ARRAY).description("관심 직무").description(generateLinkCode(DocUrl.POSITION)).optional(),
                                         fieldWithPath("interestedFields").type(ARRAY).description("관심 도메인").description(generateLinkCode(DocUrl.FIELD)).optional(),
                                         fieldWithPath("introduce").type(STRING).description("자기소개").optional()
@@ -170,7 +169,7 @@ class MenteeControllerTest extends ControllerUnitTest {
     void 멘티_정보_수정에_성공한다() throws Exception {
         // given
         Long menteeId = 1L;
-        MenteeInfoUpdateRequest request = new MenteeInfoUpdateRequest("newNick", "01033323334", Set.of("FRONT"), Set.of("RETAIL"), "안녕하세요!");
+        MenteeInfoUpdateRequest request = new MenteeInfoUpdateRequest("newNick", "01033323334", Set.of("FRONT"), Set.of("SNS"), "안녕하세요!");
         given(menteeService.update(any(Long.class), any(MenteeInfoUpdateRequest.class))).willReturn(1L);
 
         // when

--- a/src/test/java/org/devcourse/resumeme/business/user/controller/mentor/MentorControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/business/user/controller/mentor/MentorControllerTest.java
@@ -197,7 +197,6 @@ class MentorControllerTest extends ControllerUnitTest {
                                 responseFields(
                                         fieldWithPath("imageUrl").type(STRING).description("프로필 이미지"),
                                         fieldWithPath("nickname").type(STRING).description("닉네임"),
-                                        fieldWithPath("role").type(STRING).description(generateLinkCode(ROLE)),
                                         fieldWithPath("experiencedPositions").type(ARRAY).description("활동 직무").description(generateLinkCode(DocumentLinkGenerator.DocUrl.POSITION)).optional(),
                                         fieldWithPath("careerContent").type(STRING).description("경력 사항"),
                                         fieldWithPath("careerYear").type(INTEGER).description("경력 연차"),


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
- 기존에 "ROLE_XXX" 형태로 넘어가던 역할 "mentor", "mentee", "pending" 으로 교체
- 멘토/멘티 일반 단건 조회의 경우 이미 역할을 알고 있어야 요청을 보낼 수 있기 때문에 response 에서 삭제

## CC. 리뷰어


## 테스트 설명


## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
