### PR TITLE
feat: 이벤트 전체 조회 api 통합

### DIFF
--- a/src/docs/asciidoc/mentor.adoc
+++ b/src/docs/asciidoc/mentor.adoc
@@ -40,26 +40,6 @@ include::{snippets}/event/getOwn/path-parameters.adoc[]
 include::{snippets}/event/getOwn/http-response.adoc[]
 include::{snippets}/event/getOwn/response-fields.adoc[]
 
-=== 첨삭 이벤트 및 관련 이력서 리스트 조회
-
-*Request*
-include::{snippets}/event/getMyEvents/http-request.adoc[]
-
-*Response*
-include::{snippets}/event/getMyEvents/http-response.adoc[]
-include::{snippets}/event/getMyEvents/response-fields.adoc[]
-
-=== 첨삭 완료
-
-include::{snippets}/event/completeReview/exception-response.adoc[]
-
-*Request*
-include::{snippets}/event/completeReview/http-request.adoc[]
-include::{snippets}/event/completeReview/path-parameters.adoc[]
-
-*Response*
-include::{snippets}/event/completeReview/http-response.adoc[]
-
 === 첨삭 코멘트 작성
 
 *Request*

--- a/src/main/java/org/devcourse/resumeme/business/event/controller/EventController.java
+++ b/src/main/java/org/devcourse/resumeme/business/event/controller/EventController.java
@@ -117,16 +117,12 @@ public class EventController {
     @GetMapping
     public List<EventResponse> getAll(@CurrentSecurityContext(expression = "authentication") Authentication auth, @RequestParam(required = false) Long mentorId) {
         JwtUser user = (JwtUser) auth.getPrincipal();
-
-        if (mentorId != null) {
-            List<Event> eventList = eventService.getAll().stream().filter(event -> event.getMentor().getId().equals(mentorId)).toList();
-            if (isMentor(auth) && mentorId.equals(user.id())) {
-                return eventList.stream().map(event -> new EventResponse(event, eventPositionService.getAll(event.getId()), getResumes(event))).toList();
-            }
-            return eventList.stream().map(event -> new EventResponse(event, eventPositionService.getAll(event.getId()), null)).toList();
+        List<Event> eventList = eventService.getAll(mentorId);
+        if (isMentor(auth) && mentorId.equals(user.id())) {
+            return eventList.stream().map(event -> new EventResponse(event, eventPositionService.getAll(event.getId()), getResumes(event))).toList();
         }
 
-        return eventService.getAll().stream().map(event -> new EventResponse(event, eventPositionService.getAll(event.getId()), null)).toList();
+        return eventList.stream().map(event -> new EventResponse(event, eventPositionService.getAll(event.getId()), null)).toList();
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/business/event/controller/EventController.java
+++ b/src/main/java/org/devcourse/resumeme/business/event/controller/EventController.java
@@ -119,10 +119,14 @@ public class EventController {
         JwtUser user = (JwtUser) auth.getPrincipal();
         List<Event> eventList = eventService.getAll(mentorId);
         if (isMentor(auth) && mentorId.equals(user.id())) {
-            return eventList.stream().map(event -> new EventResponse(event, eventPositionService.getAll(event.getId()), getResumes(event))).toList();
+            return eventList.stream()
+                    .map(event -> new EventResponse(event, eventPositionService.getAll(event.getId()), getResumes(event)))
+                    .toList();
         }
 
-        return eventList.stream().map(event -> new EventResponse(event, eventPositionService.getAll(event.getId()), null)).toList();
+        return eventList.stream()
+                .map(event -> new EventResponse(event, eventPositionService.getAll(event.getId()), null))
+                .toList();
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/business/event/controller/dto/EventResponse.java
+++ b/src/main/java/org/devcourse/resumeme/business/event/controller/dto/EventResponse.java
@@ -5,17 +5,22 @@ import org.devcourse.resumeme.business.event.domain.EventPosition;
 import org.devcourse.resumeme.business.event.domain.EventTimeInfo;
 import org.devcourse.resumeme.business.event.domain.MenteeToEvent;
 import org.devcourse.resumeme.business.resume.domain.Resume;
+import org.devcourse.resumeme.business.user.domain.mentor.Mentor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record EventResponse(EventInfoResponse info, List<ResumeResponse> resumes) {
+public record EventResponse(EventInfoResponse info, MentorInfo mentorInfo, List<ResumeResponse> resumes) {
 
     public EventResponse(Event event, List<EventPosition> positions, List<Resume> resumes) {
-        this(new EventInfoResponse(event, positions), toResponse(event, resumes));
+        this(new EventInfoResponse(event, positions), new MentorInfo(event.getMentor()), toResponse(event, resumes));
     }
 
     public static List<ResumeResponse> toResponse(Event event, List<Resume> resumes) {
+        if (resumes == null) {
+            return null;
+        }
+
         return event.getApplicants().stream()
                 .flatMap(
                         applicant -> resumes.stream()
@@ -52,6 +57,13 @@ public record EventResponse(EventInfoResponse info, List<ResumeResponse> resumes
             this(resume.getId(), resume.menteeName(), resume.getTitle(), applicant.getProgress().name());
         }
 
+    }
+
+    record MentorInfo(Long mentorId, String nickname, String imageUrl) {
+
+        MentorInfo(Mentor mentor) {
+            this(mentor.getId(), mentor.getRequiredInfo().getNickname(), mentor.getImageUrl());
+        }
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/business/event/service/EventService.java
+++ b/src/main/java/org/devcourse/resumeme/business/event/service/EventService.java
@@ -64,7 +64,12 @@ public class EventService {
         getOne(eventId).requestReview(menteeId);
     }
 
-    public List<Event> getAll() {
+    @Transactional(readOnly = true)
+    public List<Event> getAll(Long mentorId) {
+        if (mentorId != null) {
+            return eventRepository.findAllByMentorId(mentorId);
+        }
+
         return eventRepository.findAll();
     }
 

--- a/src/main/resources/application-endpoint.yml
+++ b/src/main/resources/application-endpoint.yml
@@ -5,13 +5,13 @@ endpoint:
         post: /api/v1/mentees, /api/v1/mentors
       role: all
     - matcher:
-        get: /api/v1/mentors/*, /api/v1/mentees/*, /api/v1/resumes/*/**
+        get: /api/v1/mentors/*, /api/v1/mentees/*, /api/v1/resumes/*/**, /api/v1/events
         post: /api/v1/resumes, /api/v1/resumes/*/**
         patch: /api/v1/events/*/mentee, /api/v1/resumes/*/**
         delete:
       role: mentee
     - matcher:
-        get: /api/v1/mentors/*, /api/v1/mentees/*, /api/v1/events/own
+        get: /api/v1/mentors/*, /api/v1/mentees/*, /api/v1/events
         post: /api/v1/events, /api/v1/resumes/*/reviews, /api/v1/events/*/resumes/*/comments
         patch: /api/v1/mentors/*
       role: mentor

--- a/src/test/java/org/devcourse/resumeme/business/event/controller/EventControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/business/event/controller/EventControllerTest.java
@@ -377,7 +377,7 @@ class EventControllerTest extends ControllerUnitTest {
         eventThree.acceptMentee(5L, 11L);
         eventThree.acceptMentee(6L, 43L);
 
-        given(eventService.getAll()).willReturn(List.of(eventOne, eventTwo, eventThree));
+        given(eventService.getAll(any())).willReturn(List.of(eventOne, eventTwo, eventThree));
         Resume resume1 = new Resume("title", mentee1);
         Resume resume2 = new Resume("title", mentee2);
         setId(resume1, 1L);
@@ -386,7 +386,7 @@ class EventControllerTest extends ControllerUnitTest {
         given(eventPositionService.getAll(1L)).willReturn(List.of(new EventPosition(BACK, eventOne)));
         given(eventPositionService.getAll(2L)).willReturn(List.of(new EventPosition(DEVOPS, eventTwo)));
 
-        given(eventService.getAll()).willReturn(List.of(eventOne, eventTwo, eventThree));
+        given(eventService.getAll(any())).willReturn(List.of(eventOne, eventTwo, eventThree));
 
         // when
         ResultActions result = mvc.perform(get("/api/v1/events?mentorId=1"));


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
- 이벤트 전체 조회 api 통일 : /api/v1/events

## CC. 리뷰어
- queryParam mentorId 없을 경우 : 전체 이벤트 조회
- queryParam mentorId 있고, mentorId == 지금 로그인한 멘토 id 인 경우 : 자기가 만든 이벤트 목록 조회 + 딸린 이력서 목록
- queryParam mentorId 있는데, mentorId != 지금 로그인한 멘토 id 인 경우 : 특정 멘토가 만든 이벤트 목록들만 조회
- queryParam mentorId 있는데, 지금 로그인한 사람이 멘티인 경우 : 특정 멘토가 만든 이벤트 목록들만 조회 

## 테스트 설명


## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
