### PR TITLE
feat: 이력서, Component 반환 값 추가

### DIFF
--- a/src/main/java/org/devcourse/resumeme/business/resume/controller/career/dto/CareerResponse.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/controller/career/dto/CareerResponse.java
@@ -3,9 +3,9 @@ package org.devcourse.resumeme.business.resume.controller.career.dto;
 import lombok.Data;
 import org.devcourse.resumeme.business.resume.domain.career.Career;
 import org.devcourse.resumeme.business.resume.domain.career.Duty;
+import org.devcourse.resumeme.business.resume.entity.Component;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
@@ -27,39 +27,16 @@ public class CareerResponse extends ComponentResponse {
 
     private String careerContent;
 
-    public CareerResponse(
-            Long id, LocalDateTime createdDate, String companyName,
-            String position,
-            List<String> skills,
-            List<DutyResponse> duties,
-            boolean isCurrentlyEmployed,
-            LocalDate careerStartDate,
-            LocalDate endDate,
-            String careerContent
-    ) {
-        super(id, createdDate);
-        this.companyName = companyName;
-        this.position = position;
-        this.skills = skills;
-        this.duties = duties;
-        this.isCurrentlyEmployed = isCurrentlyEmployed;
-        this.careerStartDate = careerStartDate;
-        this.endDate = endDate;
-        this.careerContent = careerContent;
-    }
-
-    public CareerResponse(Career career, Long id, LocalDateTime createdDate) {
-        this(
-                id, createdDate,
-                career.getCompanyName(),
-                career.getPosition(),
-                career.getSkills(),
-                mapDuties(career.getDuties()),
-                career.getCareerPeriod().getEndDate() == null,
-                career.getCareerPeriod().getStartDate(),
-                career.getCareerPeriod().getEndDate(),
-                career.getCareerContent()
-        );
+    public CareerResponse(Career career, Component component) {
+        super(component);
+        this.companyName = career.getCompanyName();
+        this.position = career.getPosition();
+        this.skills = career.getSkills();
+        this.duties = mapDuties(career.getDuties());
+        this.isCurrentlyEmployed = career.getCareerPeriod().getEndDate() == null;
+        this.careerStartDate = career.getCareerPeriod().getStartDate();
+        this.endDate = career.getCareerPeriod().getEndDate();
+        this.careerContent = career.getCareerContent();
     }
 
     private static List<DutyResponse> mapDuties(List<Duty> duties) {

--- a/src/main/java/org/devcourse/resumeme/business/resume/controller/career/dto/ComponentResponse.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/controller/career/dto/ComponentResponse.java
@@ -2,6 +2,7 @@ package org.devcourse.resumeme.business.resume.controller.career.dto;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.devcourse.resumeme.business.resume.entity.Component;
 
 import java.time.LocalDateTime;
 
@@ -9,14 +10,22 @@ import java.time.LocalDateTime;
 public abstract class ComponentResponse {
 
     @Getter
-    protected Long id;
+    protected Long componentId;
+
+    @Getter
+    protected Long originComponentId;
+
+    @Getter
+    protected boolean isReflectFeedback;
 
     @Getter
     private LocalDateTime createdDate;
 
-    public ComponentResponse(Long id, LocalDateTime createdDate) {
-        this.id = id;
-        this.createdDate = createdDate;
+    protected ComponentResponse(Component component) {
+        this.componentId = component.getId();
+        this.originComponentId = component.getOriginComponentId();
+        this.isReflectFeedback = component.isReflectFeedBack();
+        this.createdDate = component.getCreatedDate();
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/business/resume/controller/dto/ActivityResponse.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/controller/dto/ActivityResponse.java
@@ -3,9 +3,9 @@ package org.devcourse.resumeme.business.resume.controller.dto;
 import lombok.Data;
 import org.devcourse.resumeme.business.resume.controller.career.dto.ComponentResponse;
 import org.devcourse.resumeme.business.resume.domain.Activity;
+import org.devcourse.resumeme.business.resume.entity.Component;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Data
 public class ActivityResponse extends ComponentResponse {
@@ -22,33 +22,14 @@ public class ActivityResponse extends ComponentResponse {
 
     private String description;
 
-    public ActivityResponse(
-            Long id, LocalDateTime createdDate, String activityName,
-            LocalDate startDate,
-            LocalDate endDate,
-            boolean inProgress,
-            String link,
-            String description
-    ) {
-        super(id, createdDate);
-        this.activityName = activityName;
-        this.startDate = startDate;
-        this.endDate = endDate;
-        this.inProgress = inProgress;
-        this.link = link;
-        this.description = description;
-    }
-
-    public ActivityResponse(Activity activity, Long id, LocalDateTime createdDate) {
-        this(
-                id, createdDate,
-                activity.getActivityName(),
-                activity.getStartDate(),
-                activity.getEndDate(),
-                activity.getEndDate() == null,
-                activity.getLink(),
-                activity.getDescription()
-        );
+    public ActivityResponse(Activity activity, Component component) {
+        super(component);
+        this.activityName = activity.getActivityName();
+        this.startDate = activity.getStartDate();
+        this.endDate = activity.getEndDate();
+        this.inProgress = activity.getEndDate() == null;
+        this.link = activity.getLink();
+        this.description = activity.getDescription();
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/business/resume/controller/dto/BasicResumeInfo.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/controller/dto/BasicResumeInfo.java
@@ -6,11 +6,11 @@ import org.devcourse.resumeme.business.user.domain.mentee.Mentee;
 import java.util.Set;
 
 public record BasicResumeInfo(String title, String position, Set<String> skills, String introduce,
-                              OwnerInfo ownerInfo) {
+                              Long originResumeId, OwnerInfo ownerInfo) {
 
     public BasicResumeInfo(Resume resume) {
         this(resume.getTitle(), resume.getResumeInfo().getPosition(), resume.getResumeInfo().getSkillSet(), resume.getResumeInfo().getIntroduce(),
-                new OwnerInfo(resume.getMentee()));
+                resume.getOriginResumeId(), new OwnerInfo(resume.getMentee()));
     }
 
     record OwnerInfo(Long id, String name, String phoneNumber) {

--- a/src/main/java/org/devcourse/resumeme/business/resume/controller/dto/CertificationResponse.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/controller/dto/CertificationResponse.java
@@ -4,8 +4,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.devcourse.resumeme.business.resume.controller.career.dto.ComponentResponse;
 import org.devcourse.resumeme.business.resume.domain.Certification;
-
-import java.time.LocalDateTime;
+import org.devcourse.resumeme.business.resume.entity.Component;
 
 @Data
 @NoArgsConstructor
@@ -21,30 +20,13 @@ public class CertificationResponse extends ComponentResponse {
 
     private String description;
 
-    public CertificationResponse(
-            Long id, LocalDateTime createdDate, String certificationTitle,
-            String acquisitionDate,
-            String issuingAuthority,
-            String link,
-            String description
-    ) {
-        super(id, createdDate);
-        this.certificationTitle = certificationTitle;
-        this.acquisitionDate = acquisitionDate;
-        this.issuingAuthority = issuingAuthority;
-        this.link = link;
-        this.description = description;
-    }
-
-    public CertificationResponse(Certification certification, Long id, LocalDateTime createdDate) {
-        this(
-                id, createdDate,
-                certification.getCertificationTitle(),
-                certification.getAcquisitionDate(),
-                certification.getIssuingAuthority(),
-                certification.getLink(),
-                certification.getDescription()
-        );
+    public CertificationResponse(Certification certification, Component component) {
+        super(component);
+        this.certificationTitle = certification.getCertificationTitle();
+        this.acquisitionDate = certification.getAcquisitionDate();
+        this.issuingAuthority = certification.getIssuingAuthority();
+        this.link = certification.getLink();
+        this.description = certification.getDescription();
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/business/resume/controller/dto/ForeignLanguageResponse.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/controller/dto/ForeignLanguageResponse.java
@@ -3,8 +3,7 @@ package org.devcourse.resumeme.business.resume.controller.dto;
 import lombok.Data;
 import org.devcourse.resumeme.business.resume.controller.career.dto.ComponentResponse;
 import org.devcourse.resumeme.business.resume.domain.ForeignLanguage;
-
-import java.time.LocalDateTime;
+import org.devcourse.resumeme.business.resume.entity.Component;
 
 @Data
 public class ForeignLanguageResponse extends ComponentResponse {
@@ -15,24 +14,11 @@ public class ForeignLanguageResponse extends ComponentResponse {
 
     private String scoreOrGrade;
 
-    public ForeignLanguageResponse(
-            Long id, LocalDateTime createdDate, String language,
-            String examName,
-            String scoreOrGrade
-    ) {
-        super(id, createdDate);
-        this.language = language;
-        this.examName = examName;
-        this.scoreOrGrade = scoreOrGrade;
-    }
-
-    public ForeignLanguageResponse(ForeignLanguage foreignLanguage, Long id, LocalDateTime createdDate) {
-        this(
-                id, createdDate,
-                foreignLanguage.getLanguage(),
-                foreignLanguage.getExamName(),
-                foreignLanguage.getScoreOrGrade()
-        );
+    public ForeignLanguageResponse(ForeignLanguage foreignLanguage, Component component) {
+        super(component);
+        this.language = foreignLanguage.getLanguage();
+        this.examName = foreignLanguage.getExamName();
+        this.scoreOrGrade = foreignLanguage.getScoreOrGrade();
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/business/resume/controller/dto/ProjectResponse.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/controller/dto/ProjectResponse.java
@@ -4,8 +4,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.devcourse.resumeme.business.resume.controller.career.dto.ComponentResponse;
 import org.devcourse.resumeme.business.resume.domain.Project;
+import org.devcourse.resumeme.business.resume.entity.Component;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
@@ -26,36 +26,15 @@ public class ProjectResponse extends ComponentResponse {
 
     private String projectUrl;
 
-    public ProjectResponse(
-            Long id, LocalDateTime createdDate, String projectName,
-            Long productionYear,
-            boolean isTeam,
-            String teamMembers,
-            List<String> skills,
-            String projectContent,
-            String projectUrl
-    ) {
-        super(id, createdDate);
-        this.projectName = projectName;
-        this.productionYear = productionYear;
-        this.isTeam = isTeam;
-        this.teamMembers = teamMembers;
-        this.skills = skills;
-        this.projectContent = projectContent;
-        this.projectUrl = projectUrl;
-    }
-
-    public ProjectResponse(Project project, Long id, LocalDateTime createdDate) {
-        this(
-                id, createdDate,
-                project.getProjectName(),
-                project.getProductionYear(),
-                !project.getTeamMembers().equals(""),
-                project.getTeamMembers(),
-                project.getSkills(),
-                project.getProjectContent(),
-                project.getProjectUrl()
-        );
+    public ProjectResponse(Project project, Component component) {
+        super(component);
+        this.projectName = project.getProjectName();
+        this.productionYear = project.getProductionYear();
+        this.isTeam = !project.getTeamMembers().equals("");
+        this.teamMembers = project.getTeamMembers();
+        this.skills = project.getSkills();
+        this.projectContent = project.getProjectContent();
+        this.projectUrl = project.getProjectUrl();
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/business/resume/controller/dto/ResumeLinkResponse.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/controller/dto/ResumeLinkResponse.java
@@ -3,8 +3,7 @@ package org.devcourse.resumeme.business.resume.controller.dto;
 import lombok.Data;
 import org.devcourse.resumeme.business.resume.controller.career.dto.ComponentResponse;
 import org.devcourse.resumeme.business.resume.domain.ReferenceLink;
-
-import java.time.LocalDateTime;
+import org.devcourse.resumeme.business.resume.entity.Component;
 
 @Data
 public class ResumeLinkResponse extends ComponentResponse {
@@ -12,8 +11,8 @@ public class ResumeLinkResponse extends ComponentResponse {
     private String linkType;
     private String url;
 
-    public ResumeLinkResponse(ReferenceLink referenceLink, Long id, LocalDateTime createdDate) {
-        super(id, createdDate);
+    public ResumeLinkResponse(ReferenceLink referenceLink, Component component) {
+        super(component);
         this.linkType = referenceLink.getLinkType().name();
         this.url = referenceLink.getAddress();
     }

--- a/src/main/java/org/devcourse/resumeme/business/resume/controller/dto/TrainingResponse.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/controller/dto/TrainingResponse.java
@@ -4,9 +4,9 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.devcourse.resumeme.business.resume.controller.career.dto.ComponentResponse;
 import org.devcourse.resumeme.business.resume.domain.Training;
+import org.devcourse.resumeme.business.resume.entity.Component;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Data
 @NoArgsConstructor
@@ -28,39 +28,16 @@ public class TrainingResponse extends ComponentResponse {
 
     private String explanation;
 
-    public TrainingResponse(
-            Long id, LocalDateTime createdDate, String organization,
-            String major,
-            String degree,
-            LocalDate admissionDate,
-            LocalDate graduationDate,
-            Double gpa,
-            Double maxGpa,
-            String explanation
-    ) {
-        super(id, createdDate);
-        this.organization = organization;
-        this.major = major;
-        this.degree = degree;
-        this.admissionDate = admissionDate;
-        this.graduationDate = graduationDate;
-        this.gpa = gpa;
-        this.maxGpa = maxGpa;
-        this.explanation = explanation;
-    }
-
-    public TrainingResponse(Training training, Long id, LocalDateTime createdDate) {
-        this(
-                id, createdDate,
-                training.getEducationalDetails().getOrganization(),
-                training.getEducationalDetails().getMajor(),
-                training.getEducationalDetails().getDegree(),
-                training.getDateDetails().getAdmissionDate(),
-                training.getDateDetails().getGraduationDate(),
-                training.getGpaDetails().getGpa(),
-                training.getGpaDetails().getMaxGpa(),
-                training.getExplanation()
-        );
+    public TrainingResponse(Training training, Component component) {
+        super(component);
+        this.organization = training.getEducationalDetails().getOrganization();
+        this.major = training.getEducationalDetails().getMajor();
+        this.degree = training.getEducationalDetails().getDegree();
+        this.admissionDate = training.getDateDetails().getAdmissionDate();
+        this.graduationDate = training.getDateDetails().getGraduationDate();
+        this.gpa = training.getGpaDetails().getGpa();
+        this.maxGpa = training.getGpaDetails().getMaxGpa();
+        this.explanation = training.getExplanation();
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/business/resume/domain/BlockType.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/domain/BlockType.java
@@ -26,13 +26,13 @@ import java.util.function.Function;
 
 public enum BlockType implements DocsEnumType {
 
-    ACTIVITY("활동", "activities", ActivityCreateRequest.class, component -> new ActivityResponse(Activity.from(component), component.getId(), component.getCreatedDate())),
-    CAREER("업무경험", "careers", CareerCreateRequest.class, component -> new CareerResponse(Career.from(component), component.getId(), component.getCreatedDate())),
-    CERTIFICATION("수상 및 자격증", "certifications", CertificationCreateRequest.class, component -> new CertificationResponse(Certification.from(component), component.getId(), component.getCreatedDate())),
-    FOREIGN_LANGUAGE("외국어", "foreign-languages", ForeignLanguageCreateRequest.class, component -> new ForeignLanguageResponse(ForeignLanguage.from(component), component.getId(), component.getCreatedDate())),
-    PROJECT("프로젝트", "projects", ProjectCreateRequest.class, component -> new ProjectResponse(Project.from(component), component.getId(), component.getCreatedDate())),
-    TRAINING("교육", "trainings", TrainingCreateRequest.class, component -> new TrainingResponse(Training.from(component), component.getId(), component.getCreatedDate())),
-    LINK("외부 링크", "links", ResumeLinkRequest.class, component -> new ResumeLinkResponse(ReferenceLink.from(component), component.getId(), component.getCreatedDate()));
+    ACTIVITY("활동", "activities", ActivityCreateRequest.class, component -> new ActivityResponse(Activity.from(component), component)),
+    CAREER("업무경험", "careers", CareerCreateRequest.class, component -> new CareerResponse(Career.from(component), component)),
+    CERTIFICATION("수상 및 자격증", "certifications", CertificationCreateRequest.class, component -> new CertificationResponse(Certification.from(component), component)),
+    FOREIGN_LANGUAGE("외국어", "foreign-languages", ForeignLanguageCreateRequest.class, component -> new ForeignLanguageResponse(ForeignLanguage.from(component), component)),
+    PROJECT("프로젝트", "projects", ProjectCreateRequest.class, component -> new ProjectResponse(Project.from(component), component)),
+    TRAINING("교육", "trainings", TrainingCreateRequest.class, component -> new TrainingResponse(Training.from(component), component)),
+    LINK("외부 링크", "links", ResumeLinkRequest.class, component -> new ResumeLinkResponse(ReferenceLink.from(component), component));
 
     private final String description;
 

--- a/src/main/java/org/devcourse/resumeme/business/resume/domain/Resume.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/domain/Resume.java
@@ -41,6 +41,9 @@ public class Resume extends BaseEntity {
     @Embedded
     private ResumeInfo resumeInfo = new ResumeInfo();
 
+    @Getter
+    private Long originResumeId;
+
     private boolean openStatus;
 
     private boolean deleted = false;
@@ -58,15 +61,16 @@ public class Resume extends BaseEntity {
     }
 
     @Builder
-    private Resume(Long id, String title, Mentee mentee, ResumeInfo resumeInfo) {
+    private Resume(Long id, String title, Mentee mentee, ResumeInfo resumeInfo, Long originResumeId) {
         this.id = id;
         this.title = title;
         this.mentee = mentee;
         this.resumeInfo = resumeInfo;
+        this.originResumeId = originResumeId;
     }
 
     public Resume copy() {
-        return new Resume(null, title, mentee, resumeInfo);
+        return new Resume(null, title, mentee, resumeInfo, id);
     }
 
     public Long menteeId() {

--- a/src/main/java/org/devcourse/resumeme/business/resume/entity/Component.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/entity/Component.java
@@ -90,6 +90,10 @@ public class Component {
         this.createdDate = createdDate;
         this.lastModifiedDate = LocalDateTime.now();
 
+        if (originComponentId != null) {
+            isReflectFeedBack = true;
+        }
+
         if (components != null) {
             components.forEach(subComponent -> subComponent.updateOriginDate(createdDate));
         }

--- a/src/main/java/org/devcourse/resumeme/business/resume/entity/Component.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/entity/Component.java
@@ -41,6 +41,12 @@ public class Component {
     @Getter
     private Long resumeId;
 
+    @Getter
+    private Long originComponentId;
+
+    @Getter
+    private boolean isReflectFeedBack;
+
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "parent_id")
     private Component component;

--- a/src/main/java/org/devcourse/resumeme/business/resume/repository/ComponentCustomRepositoryImpl.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/repository/ComponentCustomRepositoryImpl.java
@@ -13,9 +13,9 @@ public class ComponentCustomRepositoryImpl implements ComponentCustomRepository{
     public void copy(Long originResumeId, Long newResumeId) {
         em.createQuery("""
                 insert into Component (
-                    property, content, startDate, endDate, resumeId, component, createdDate, lastModifiedDate
+                    property, content, startDate, endDate, resumeId, component, createdDate, lastModifiedDate, originComponentId
                 )
-                select c.property,c.content,c.startDate,c.endDate, :newResumeId, c.component,c.createdDate,c.lastModifiedDate
+                select c.property,c.content,c.startDate,c.endDate, :newResumeId, c.component,c.createdDate,c.lastModifiedDate, c.id
                 from Component c
                 where c.resumeId = :originResumeId
                 """)

--- a/src/test/java/org/devcourse/resumeme/business/resume/controller/ComponentControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/business/resume/controller/ComponentControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.restdocs.payload.RequestFieldsSnippet;
 import org.springframework.restdocs.payload.ResponseFieldsSnippet;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -177,6 +178,9 @@ class ComponentControllerTest extends ControllerUnitTest {
         Component component = getComponent(request);
         Component superComponent = new Component(type, null, null, null, 1L, List.of(component));
         setId(component, 1L);
+        Field field = component.getClass().getDeclaredField("originComponentId");
+        field.setAccessible(true);
+        field.set(component, 2L);
         given(componentService.getAll(1L)).willReturn(List.of(superComponent));
 
         // when

--- a/src/test/java/org/devcourse/resumeme/business/resume/controller/ComponentResponse.java
+++ b/src/test/java/org/devcourse/resumeme/business/resume/controller/ComponentResponse.java
@@ -15,7 +15,9 @@ public class ComponentResponse {
 
     public static ResponseFieldsSnippet activityResponseSnippet() {
         return responseFields(
-                fieldWithPath("activities.[].id").type(NUMBER).description("블럭 아이디"),
+                fieldWithPath("activities.[].componentId").type(NUMBER).description("블럭 아이디"),
+                fieldWithPath("activities.[].originComponentId").type(NUMBER).description("원본 이력서 블럭 아이디 (Null 가능)"),
+                fieldWithPath("activities.[].reflectFeedback").type(BOOLEAN).description("피드백 반영 여부"),
                 fieldWithPath("activities.[].activityName").type(STRING).description("활동명"),
                 fieldWithPath("activities.[].startDate").type(STRING).description("시작일"),
                 fieldWithPath("activities.[].endDate").type(STRING).description("종료일"),
@@ -28,7 +30,9 @@ public class ComponentResponse {
 
     public static ResponseFieldsSnippet careerResponseSnippet() {
         return responseFields(
-                fieldWithPath("careers.[].id").type(NUMBER).description("블럭 아이디"),
+                fieldWithPath("careers.[].componentId").type(NUMBER).description("블럭 아이디"),
+                fieldWithPath("careers.[].originComponentId").type(NUMBER).description("원본 이력서 블럭 아이디 (Null 가능)"),
+                fieldWithPath("careers.[].reflectFeedback").type(BOOLEAN).description("피드백 반영 여부"),
                 fieldWithPath("careers.[].companyName").type(STRING).description("회사명"),
                 fieldWithPath("careers.[].position").type(STRING).description("직책"),
                 fieldWithPath("careers.[].skills").type(ARRAY).description("기술 목록"),
@@ -46,7 +50,9 @@ public class ComponentResponse {
 
     public static ResponseFieldsSnippet certificationResponseSnippet() {
         return responseFields(
-                fieldWithPath("certifications.[].id").type(NUMBER).description("블럭 아이디"),
+                fieldWithPath("certifications.[].componentId").type(NUMBER).description("블럭 아이디"),
+                fieldWithPath("certifications.[].originComponentId").type(NUMBER).description("원본 이력서 블럭 아이디 (Null 가능)"),
+                fieldWithPath("certifications.[].reflectFeedback").type(BOOLEAN).description("피드백 반영 여부"),
                 fieldWithPath("certifications.[].certificationTitle").type(STRING).description("자격증 제목"),
                 fieldWithPath("certifications.[].acquisitionDate").type(STRING).description("취득 일자"),
                 fieldWithPath("certifications.[].issuingAuthority").type(STRING).description("발급 기관"),
@@ -58,7 +64,9 @@ public class ComponentResponse {
 
     public static ResponseFieldsSnippet foreignLanguageResponseSnippet() {
         return responseFields(
-                fieldWithPath("foreign-languages.[].id").type(NUMBER).description("블럭 아이디"),
+                fieldWithPath("foreign-languages.[].componentId").type(NUMBER).description("블럭 아이디"),
+                fieldWithPath("foreign-languages.[].originComponentId").type(NUMBER).description("원본 이력서 블럭 아이디 (Null 가능)"),
+                fieldWithPath("foreign-languages.[].reflectFeedback").type(BOOLEAN).description("피드백 반영 여부"),
                 fieldWithPath("foreign-languages.[].language").type(STRING).description("언어"),
                 fieldWithPath("foreign-languages.[].examName").type(STRING).description("시험명"),
                 fieldWithPath("foreign-languages.[].scoreOrGrade").type(STRING).description("점수 또는 학점"),
@@ -68,7 +76,9 @@ public class ComponentResponse {
 
     public static ResponseFieldsSnippet linkResponseSnippet() {
         return responseFields(
-                fieldWithPath("links.[].id").type(NUMBER).description("블럭 아이디"),
+                fieldWithPath("links.[].componentId").type(NUMBER).description("블럭 아이디"),
+                fieldWithPath("links.[].originComponentId").type(NUMBER).description("원본 이력서 블럭 아이디 (Null 가능)"),
+                fieldWithPath("links.[].reflectFeedback").type(BOOLEAN).description("피드백 반영 여부"),
                 fieldWithPath("links.[].linkType").type(STRING).description(generateLinkCode(BLOCK_TYPE)),
                 fieldWithPath("links.[].url").type(STRING).description("링크 URL"),
                 fieldWithPath("links.[].createdDate").type(STRING).description("생성 시간")
@@ -77,7 +87,9 @@ public class ComponentResponse {
 
     public static ResponseFieldsSnippet projectResponseSnippet() {
         return responseFields(
-                fieldWithPath("projects.[].id").type(NUMBER).description("블럭 아이디"),
+                fieldWithPath("projects.[].componentId").type(NUMBER).description("블럭 아이디"),
+                fieldWithPath("projects.[].originComponentId").type(NUMBER).description("원본 이력서 블럭 아이디 (Null 가능)"),
+                fieldWithPath("projects.[].reflectFeedback").type(BOOLEAN).description("피드백 반영 여부"),
                 fieldWithPath("projects.[]projectName").type(STRING).description("프로젝트명"),
                 fieldWithPath("projects.[]productionYear").type(NUMBER).description("제작 연도"),
                 fieldWithPath("projects.[]team").type(BOOLEAN).description("팀 프로젝트 여부"),
@@ -91,7 +103,9 @@ public class ComponentResponse {
 
     public static ResponseFieldsSnippet trainingResponseSnippet() {
         return responseFields(
-                fieldWithPath("trainings.[].id").type(NUMBER).description("블럭 아이디"),
+                fieldWithPath("trainings.[].componentId").type(NUMBER).description("블럭 아이디"),
+                fieldWithPath("trainings.[].originComponentId").type(NUMBER).description("원본 이력서 블럭 아이디 (Null 가능)"),
+                fieldWithPath("trainings.[].reflectFeedback").type(BOOLEAN).description("피드백 반영 여부"),
                 fieldWithPath("trainings.[].organization").type(STRING).description("기관명"),
                 fieldWithPath("trainings.[].major").type(STRING).description("전공"),
                 fieldWithPath("trainings.[].degree").type(STRING).description("학위"),

--- a/src/test/java/org/devcourse/resumeme/business/resume/controller/ResumeControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/business/resume/controller/ResumeControllerTest.java
@@ -116,6 +116,9 @@ class ResumeControllerTest extends ControllerUnitTest {
                 .resumeInfo(new ResumeInfo("백엔드", List.of("자바", "스프링"), "안녕하세요"))
                 .mentee(mentee)
                 .build();
+        Field field = resume.getClass().getDeclaredField("originResumeId");
+        field.setAccessible(true);
+        field.set(resume, 2L);
         given(resumeService.getOne(resumeId)).willReturn(resume);
 
         // when
@@ -135,6 +138,7 @@ class ResumeControllerTest extends ControllerUnitTest {
                                         fieldWithPath("position").type(STRING).description("지원 분야"),
                                         fieldWithPath("skills").type(ARRAY).description("사용 기술"),
                                         fieldWithPath("introduce").type(STRING).description("자기소개글"),
+                                        fieldWithPath("originResumeId").type(NUMBER).description("원본 복사 전 이력서 아이디 (NULL 가능)"),
                                         fieldWithPath("ownerInfo").type(OBJECT).description("작성자 정보"),
                                         fieldWithPath("ownerInfo.id").type(NUMBER).description("작성자 아이디"),
                                         fieldWithPath("ownerInfo.name").type(STRING).description("작성자 이름"),
@@ -143,7 +147,6 @@ class ResumeControllerTest extends ControllerUnitTest {
                         )
                 );
     }
-
 
     @Test
     @WithMockCustomUser


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
이력서, Component 반환 값 추가

## CC. 리뷰어
이력서 첨삭 완료 후 수정페이지내에서 사용합니다

- 원본 이력서 아이디 : 1번
- 이벤트에 참여하기 위해 복사된 이력서 아이디 : 2번

수정 페이지에서 사용할 API
1. 2번 이력서 기본정보 조회
2. 2번 이력서 component 조회
3. 2번 이력서에 대한 피드백 조회
4. 1번 이력서 component 조회

이력서 기본 정보 조회에 원본 이력서 아이디 값을 추가했습니다
Component 조회 시 원본 Component 아이디 값을 추가했습니다
복사 된 이력서에서 원본 Component를 보여줄지 여부를 위해 피드백 반영 여부 값을 추가했습니다

## 테스트 설명


## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
