### PR TITLE
feat: 중복 endpoint 처리 manager 추가

### DIFF
--- a/src/main/java/org/devcourse/resumeme/global/auth/service/authorization/DelegatingAuthorizationManager.java
+++ b/src/main/java/org/devcourse/resumeme/global/auth/service/authorization/DelegatingAuthorizationManager.java
@@ -1,0 +1,37 @@
+package org.devcourse.resumeme.global.auth.service.authorization;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+@Slf4j
+public class DelegatingAuthorizationManager implements AuthorizationManager<RequestAuthorizationContext> {
+
+    private final List<AuthorizationManager<RequestAuthorizationContext>> managers;
+
+    public DelegatingAuthorizationManager(List<AuthorizationManager<RequestAuthorizationContext>> managers) {
+        this.managers = managers;
+    }
+
+    @Override
+    public AuthorizationDecision check(Supplier<Authentication> authentication, RequestAuthorizationContext object) {
+        String uri = object.getRequest().getRequestURI();
+        for (AuthorizationManager<RequestAuthorizationContext> manager : managers) {
+            if (manager.check(authentication, object).isGranted()) {
+                log.info("can Access to entry point to {}", uri);
+
+                return new AuthorizationDecision(true);
+            }
+        }
+
+        log.info("cannot Access to entry point to {}", uri);
+
+        return new AuthorizationDecision(false);
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/devcourse/resumeme/global/config/security/SecurityConfig.java
@@ -48,11 +48,12 @@ public class SecurityConfig {
                 .cors(withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
-                .logout((logout) -> logout.logoutUrl("/api/v1/logout")
+                .logout(logout -> logout.logoutUrl("/api/v1/logout")
                         .addLogoutHandler(customLogoutHandler)
                         .logoutSuccessHandler(logoutSuccessHandler)
                         .permitAll()
-                );
+                )
+                .exceptionHandling(AbstractHttpConfigurer::disable);
 
         http.addFilterBefore(exceptionHandlerFilter, LogoutFilter.class);
         http.addFilterAfter(jwtAuthorizationFilter, ExceptionHandlerFilter.class);


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
중복 endpoint 처리 manager 추가

## CC. 리뷰어
DelegatingAuthorizationManager를 통해 중복 endpoint에 대해 권한 관리 할 수 있도록 변경

기존에는 중복 endpoint여도 먼저 잡히는 manager에 대해서만 관리가 되었는데 이제는 하나의 endpoint에 여러 권한 manager를 관리 할 수 있습니다

api 다 호출 해봤는데 실패 경우 400으로 나옴

## 테스트 설명


## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
