### PR TITLE
feat: comment component 연관관계 분리

### DIFF
--- a/src/main/java/org/devcourse/resumeme/business/comment/controller/CommentController.java
+++ b/src/main/java/org/devcourse/resumeme/business/comment/controller/CommentController.java
@@ -4,14 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.devcourse.resumeme.business.comment.controller.dto.CommentCreateRequest;
 import org.devcourse.resumeme.business.comment.controller.dto.CommentResponse;
 import org.devcourse.resumeme.business.comment.controller.dto.CommentUpdateRequest;
-import org.devcourse.resumeme.business.event.domain.Event;
-import org.devcourse.resumeme.business.resume.domain.Resume;
 import org.devcourse.resumeme.business.comment.domain.Comment;
-import org.devcourse.resumeme.business.event.service.EventService;
-import org.devcourse.resumeme.business.resume.entity.Component;
-import org.devcourse.resumeme.business.resume.service.ComponentService;
-import org.devcourse.resumeme.business.resume.service.ResumeService;
 import org.devcourse.resumeme.business.comment.service.CommentService;
+import org.devcourse.resumeme.business.event.domain.Event;
+import org.devcourse.resumeme.business.event.service.EventService;
+import org.devcourse.resumeme.business.resume.domain.Resume;
+import org.devcourse.resumeme.business.resume.service.ResumeService;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -34,15 +32,12 @@ public class CommentController {
 
     private final EventService eventService;
 
-    private final ComponentService componentService;
-
     @PostMapping
     public CommentResponse createReview(@PathVariable Long resumeId, @RequestBody CommentCreateRequest request) {
         Resume resume = resumeService.getOne(resumeId);
-        Component component = componentService.getOne(request.componentId());
-        Comment review = commentService.create(request.toEntity(resume, component), resumeId);
+        Comment review = commentService.create(request.toEntity(resume), resumeId);
 
-        return new CommentResponse(review.getId(), review.getContent(), component.getId(), review.getLastModifiedDate());
+        return new CommentResponse(review.getId(), review.getContent(), request.componentId(), review.getLastModifiedDate());
     }
 
     @GetMapping

--- a/src/main/java/org/devcourse/resumeme/business/comment/controller/dto/CommentCreateRequest.java
+++ b/src/main/java/org/devcourse/resumeme/business/comment/controller/dto/CommentCreateRequest.java
@@ -2,12 +2,11 @@ package org.devcourse.resumeme.business.comment.controller.dto;
 
 import org.devcourse.resumeme.business.comment.domain.Comment;
 import org.devcourse.resumeme.business.resume.domain.Resume;
-import org.devcourse.resumeme.business.resume.entity.Component;
 
 public record CommentCreateRequest(Long componentId, String content) {
 
-    public Comment toEntity(Resume resume, Component component) {
-        return new Comment(content, component, resume);
+    public Comment toEntity(Resume resume) {
+        return new Comment(content, componentId, resume);
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/business/comment/controller/dto/CommentResponse.java
+++ b/src/main/java/org/devcourse/resumeme/business/comment/controller/dto/CommentResponse.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 public record CommentResponse(Long commentId, String content, Long componentId, LocalDateTime lastModifiedAt) {
 
     public CommentResponse(Comment comment) {
-        this(comment.getId(), comment.getContent(), comment.getComponent().getId(), comment.getLastModifiedDate());
+        this(comment.getId(), comment.getContent(), comment.getComponentId(), comment.getLastModifiedDate());
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/business/comment/domain/Comment.java
+++ b/src/main/java/org/devcourse/resumeme/business/comment/domain/Comment.java
@@ -9,7 +9,6 @@ import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.devcourse.resumeme.business.resume.domain.Resume;
-import org.devcourse.resumeme.business.resume.entity.Component;
 import org.devcourse.resumeme.common.domain.BaseEntity;
 import org.devcourse.resumeme.global.exception.CustomException;
 
@@ -35,22 +34,20 @@ public class Comment extends BaseEntity {
     private String content;
 
     @Getter
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "component_id")
-    private Component component;
+    private Long componentId;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "resume_id")
     private Resume resume;
 
-    public Comment(String content, Component component, Resume resume) {
+    public Comment(String content, Long componentId, Resume resume) {
         check(isBlank(content), NO_EMPTY_VALUE);
         notNull(resume);
-        notNull(component);
+        notNull(componentId);
 
         this.content = content;
         this.resume = resume;
-        this.component = component;
+        this.componentId = componentId;
     }
 
     public void checkSameResume(Long resumeId) {

--- a/src/test/java/org/devcourse/resumeme/business/comment/controller/CommentControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/business/comment/controller/CommentControllerTest.java
@@ -85,7 +85,7 @@ class CommentControllerTest extends ControllerUnitTest {
         Component component = new Component("career", "career", null, null, resumeId, List.of());
         Resume resume = new Resume("titlem", mentee);
 
-        Comment comment = request.toEntity(resume, component);
+        Comment comment = request.toEntity(resume);
         setId(comment, 1L);
         setId(component, 1L);
         Field lastModifiedAt = comment.getClass().getSuperclass().getDeclaredField("lastModifiedDate");
@@ -135,7 +135,7 @@ class CommentControllerTest extends ControllerUnitTest {
         event.acceptMentee(1L, 1L);
 
         given(eventService.getOne(eventId)).willReturn(event);
-        Comment comment = new Comment("리뷰 내용내용", component, new Resume("title", mentee));
+        Comment comment = new Comment("리뷰 내용내용", 1L, new Resume("title", mentee));
         setId(comment, 1L);
         setId(component, 1L);
         Field lastModifiedAt = comment.getClass().getSuperclass().getDeclaredField("lastModifiedDate");

--- a/src/test/java/org/devcourse/resumeme/business/comment/domain/CommentTest.java
+++ b/src/test/java/org/devcourse/resumeme/business/comment/domain/CommentTest.java
@@ -45,7 +45,7 @@ class CommentTest {
         Component component = new Component("career", "career", null, null, 1L, List.of());
 
         // when
-        Comment comment = new Comment(content, component, resume);
+        Comment comment = new Comment(content, 1L, resume);
 
         // then
         assertThat(comment).isNotNull();
@@ -53,9 +53,9 @@ class CommentTest {
 
     @ParameterizedTest
     @MethodSource("reviewCreate")
-    void 이벤트포지션_생성_검증조건_미달로인해_생성에_실패한다_null입력_오류(String content, BlockType type, Component component, Resume resume) {
+    void 이벤트포지션_생성_검증조건_미달로인해_생성에_실패한다_null입력_오류(String content, BlockType type, Long componentId, Resume resume) {
         // then
-        assertThatThrownBy(() -> new Comment(content, component, resume))
+        assertThatThrownBy(() -> new Comment(content, componentId, resume))
                 .isInstanceOf(CustomException.class);
     }
 
@@ -76,14 +76,12 @@ class CommentTest {
 
         Resume resume = new Resume("title", mentee);
 
-        Component component = new Component("career", "career", null, null, 1L, List.of());
-
         return Stream.of(
-                Arguments.of(null, null, component, null),
-                Arguments.of(content, null, component, null),
-                Arguments.of(null, type, component, null),
-                Arguments.of(null, null, component, resume),
-                Arguments.of("", type, component, null),
+                Arguments.of(null, null, 1L, null),
+                Arguments.of(content, null, 1L, null),
+                Arguments.of(null, type, 1L, null),
+                Arguments.of(null, null, 1L, resume),
+                Arguments.of("", type, 1L, null),
                 Arguments.of("   ", null, null, resume)
         );
     }


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
comment component 연관관계 분리

## CC. 리뷰어
Comment경우 component가 변경이 되더라도 id값은 변경이 이루어 지면 안되기 때문에 연관관계를 분리했습니다

Comment가 달린 후 에 Component가 수정이 될 경우 현재 Component를 삭제 후 재 저장하는 과정을 가지는데 이 경우 fk 제약조건에 걸려 수정이 불가한 이유도 있습니다

## 테스트 설명


## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
