### PR TITLE
refactor: 이력서 업데이트 api 통합

### DIFF
--- a/src/docs/asciidoc/mentee.adoc
+++ b/src/docs/asciidoc/mentee.adoc
@@ -175,6 +175,15 @@ include::{snippets}/resume/updateTitle/request-fields.adoc[]
 include::{snippets}/resume/updateTitle/http-response.adoc[]
 include::{snippets}/resume/updateTitle/response-fields.adoc[]
 
+=== 이력서 제목 수정 V2
+*Request*
+include::{snippets}/resume/v2/updateTitle/http-request.adoc[]
+include::{snippets}/resume/v2/updateTitle/path-parameters.adoc[]
+
+*Response*
+include::{snippets}/resume/v2/updateTitle/http-response.adoc[]
+include::{snippets}/resume/v2/updateTitle/response-fields.adoc[]
+
 === 이력서 기본정보 수정
 *Request*
 include::{snippets}/resume/update/http-request.adoc[]
@@ -184,6 +193,15 @@ include::{snippets}/resume/update/request-fields.adoc[]
 include::{snippets}/resume/update/http-response.adoc[]
 include::{snippets}/resume/update/response-fields.adoc[]
 
+=== 이력서 기본정보 수정 V2
+*Request*
+include::{snippets}/resume/v2/updateBasicInfo/http-request.adoc[]
+include::{snippets}/resume/v2/updateBasicInfo/path-parameters.adoc[]
+
+*Response*
+include::{snippets}/resume/v2/updateBasicInfo/http-response.adoc[]
+include::{snippets}/resume/v2/updateBasicInfo/response-fields.adoc[]
+
 === 이력서 메모 수정
 *Request*
 include::{snippets}/resume/updateMemo/http-request.adoc[]
@@ -192,6 +210,15 @@ include::{snippets}/resume/updateMemo/request-fields.adoc[]
 *Response*
 include::{snippets}/resume/updateMemo/http-response.adoc[]
 include::{snippets}/resume/updateMemo/response-fields.adoc[]
+
+=== 이력서 메모 수정 V2
+*Request*
+include::{snippets}/resume/v2/updateMemo/http-request.adoc[]
+include::{snippets}/resume/v2/updateMemo/path-parameters.adoc[]
+
+*Response*
+include::{snippets}/resume/v2/updateMemo/http-response.adoc[]
+include::{snippets}/resume/v2/updateMemo/response-fields.adoc[]
 
 === 멘티 이력서 리스트 조회
 *Request*

--- a/src/main/java/org/devcourse/resumeme/business/resume/controller/ResumeController.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/controller/ResumeController.java
@@ -7,7 +7,6 @@ import org.devcourse.resumeme.business.event.service.MenteeToEventService;
 import org.devcourse.resumeme.business.resume.controller.dto.BasicResumeInfo;
 import org.devcourse.resumeme.business.resume.controller.dto.ResumeInfoRequest;
 import org.devcourse.resumeme.business.resume.controller.dto.ResumeMemoRequest;
-import org.devcourse.resumeme.business.resume.controller.dto.ResumeMemoResponse;
 import org.devcourse.resumeme.business.resume.controller.dto.ResumeRequest;
 import org.devcourse.resumeme.business.resume.controller.dto.ResumeResponse;
 import org.devcourse.resumeme.business.resume.domain.Resume;
@@ -53,20 +52,13 @@ public class ResumeController {
 
         return new BasicResumeInfo(resume);
     }
-    
+
     @PatchMapping("/{resumeId}/basic")
     public IdResponse updateResume(@PathVariable Long resumeId, @RequestBody ResumeInfoRequest request) {
         Resume resume = resumeService.getOne(resumeId);
         ResumeInfo resumeInfo = request.toEntity();
 
         return new IdResponse(resumeService.updateResumeInfo(resume, resumeInfo));
-    }
-
-    @GetMapping("/{resumeId}/memo")
-    public ResumeMemoResponse getMemo(@PathVariable Long resumeId) {
-        Resume resume = resumeService.getOne(resumeId);
-
-        return new ResumeMemoResponse(resume);
     }
 
     @PatchMapping("/{resumeId}/memo")

--- a/src/main/java/org/devcourse/resumeme/business/resume/controller/ResumeControllerV2.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/controller/ResumeControllerV2.java
@@ -1,0 +1,29 @@
+package org.devcourse.resumeme.business.resume.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.devcourse.resumeme.business.resume.controller.dto.v2.ResumeUpdateRequest;
+import org.devcourse.resumeme.business.resume.service.ResumeService;
+import org.devcourse.resumeme.business.resume.service.v2.ResumeUpdateVo;
+import org.devcourse.resumeme.common.response.IdResponse;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/resumes")
+public class ResumeControllerV2 {
+
+    private final ResumeService resumeService;
+
+    @PatchMapping("/{resumeId}")
+    public IdResponse updateResume(@PathVariable Long resumeId, @RequestBody ResumeUpdateRequest request) {
+        ResumeUpdateVo update = request.toVo();
+        resumeService.update(resumeId, update);
+
+        return new IdResponse(resumeId);
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/business/resume/controller/dto/ResumeResponse.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/controller/dto/ResumeResponse.java
@@ -8,7 +8,8 @@ public record ResumeResponse(
         Long id,
         String title,
         LocalDateTime modifiedAt,
-        String position
+        String position,
+        String memo
 ) {
 
     public ResumeResponse(Resume resume) {
@@ -16,7 +17,8 @@ public record ResumeResponse(
                 resume.getId(),
                 resume.getTitle(),
                 resume.getLastModifiedDate(),
-                resume.getResumeInfo().getPosition()
+                resume.getResumeInfo().getPosition(),
+                resume.getMemo()
         );
     }
 }

--- a/src/main/java/org/devcourse/resumeme/business/resume/controller/dto/v2/ResumeUpdateRequest.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/controller/dto/v2/ResumeUpdateRequest.java
@@ -1,0 +1,47 @@
+package org.devcourse.resumeme.business.resume.controller.dto.v2;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.devcourse.resumeme.business.resume.service.v2.ResumeBasicInfoUpdate;
+import org.devcourse.resumeme.business.resume.service.v2.ResumeMemoUpdate;
+import org.devcourse.resumeme.business.resume.service.v2.ResumeTitleUpdate;
+import org.devcourse.resumeme.business.resume.service.v2.ResumeUpdateVo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ResumeUpdateRequest {
+
+    private String position;
+
+    private List<String> skills = new ArrayList<>();
+
+    private String introduce;
+
+    private String memo;
+
+    private String title;
+
+    public ResumeUpdateRequest(String position, List<String> skills, String introduce, String memo, String title) {
+        this.position = position;
+        this.skills = skills;
+        this.introduce = introduce;
+        this.memo = memo;
+        this.title = title;
+    }
+
+    public ResumeUpdateVo toVo() {
+        if (title != null) {
+            return new ResumeTitleUpdate(title);
+        }
+
+        if (memo != null) {
+            return new ResumeMemoUpdate(memo);
+        }
+
+        return new ResumeBasicInfoUpdate(position, skills, introduce);
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/business/resume/domain/model/ResumeBasicInfoUpdateModel.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/domain/model/ResumeBasicInfoUpdateModel.java
@@ -1,0 +1,19 @@
+package org.devcourse.resumeme.business.resume.domain.model;
+
+import org.devcourse.resumeme.business.resume.domain.Resume;
+import org.devcourse.resumeme.business.resume.domain.ResumeInfo;
+
+public class ResumeBasicInfoUpdateModel implements ResumeUpdateModel {
+
+    private ResumeInfo resumeInfo;
+
+    public ResumeBasicInfoUpdateModel(ResumeInfo resumeInfo) {
+        this.resumeInfo = resumeInfo;
+    }
+
+    @Override
+    public void update(Resume resume) {
+        resume.updateResumeInfo(resumeInfo);
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/business/resume/domain/model/ResumeMemoUpdateModel.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/domain/model/ResumeMemoUpdateModel.java
@@ -1,0 +1,18 @@
+package org.devcourse.resumeme.business.resume.domain.model;
+
+import org.devcourse.resumeme.business.resume.domain.Resume;
+
+public class ResumeMemoUpdateModel implements ResumeUpdateModel {
+
+    private String memo;
+
+    public ResumeMemoUpdateModel(String memo) {
+        this.memo = memo;
+    }
+
+    @Override
+    public void update(Resume resume) {
+        resume.updateMeme(memo);
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/business/resume/domain/model/ResumeTitleUpdateModel.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/domain/model/ResumeTitleUpdateModel.java
@@ -1,0 +1,18 @@
+package org.devcourse.resumeme.business.resume.domain.model;
+
+import org.devcourse.resumeme.business.resume.domain.Resume;
+
+public class ResumeTitleUpdateModel implements ResumeUpdateModel {
+
+    private String title;
+
+    public ResumeTitleUpdateModel(String title) {
+        this.title = title;
+    }
+
+    @Override
+    public void update(Resume resume) {
+        resume.updateTitle(title);
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/business/resume/domain/model/ResumeUpdateModel.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/domain/model/ResumeUpdateModel.java
@@ -1,0 +1,9 @@
+package org.devcourse.resumeme.business.resume.domain.model;
+
+import org.devcourse.resumeme.business.resume.domain.Resume;
+
+public interface ResumeUpdateModel {
+
+    void update(Resume resume);
+
+}

--- a/src/main/java/org/devcourse/resumeme/business/resume/service/ResumeService.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/service/ResumeService.java
@@ -3,7 +3,9 @@ package org.devcourse.resumeme.business.resume.service;
 import lombok.RequiredArgsConstructor;
 import org.devcourse.resumeme.business.resume.domain.Resume;
 import org.devcourse.resumeme.business.resume.domain.ResumeInfo;
+import org.devcourse.resumeme.business.resume.domain.model.ResumeUpdateModel;
 import org.devcourse.resumeme.business.resume.repository.ResumeRepository;
+import org.devcourse.resumeme.business.resume.service.v2.ResumeUpdateVo;
 import org.devcourse.resumeme.global.exception.CustomException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -69,6 +71,14 @@ public class ResumeService {
 
         resumeRepository.delete(resume);
     }
+
+    public void update(Long resumeId, ResumeUpdateVo update) {
+        Resume resume = getOne(resumeId);
+        ResumeUpdateModel model = update.toModel();
+
+        model.update(resume);
+    }
+
 
     public Long finishUpdate(Long resumeId) {
         Resume resume = getOne(resumeId);

--- a/src/main/java/org/devcourse/resumeme/business/resume/service/v2/ResumeBasicInfoUpdate.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/service/v2/ResumeBasicInfoUpdate.java
@@ -1,0 +1,30 @@
+package org.devcourse.resumeme.business.resume.service.v2;
+
+import org.devcourse.resumeme.business.resume.domain.ResumeInfo;
+import org.devcourse.resumeme.business.resume.domain.model.ResumeBasicInfoUpdateModel;
+import org.devcourse.resumeme.business.resume.domain.model.ResumeUpdateModel;
+
+import java.util.List;
+
+public class ResumeBasicInfoUpdate implements ResumeUpdateVo {
+
+    private String position;
+
+    private List<String> skills;
+
+    private String introduce;
+
+    public ResumeBasicInfoUpdate(String position, List<String> skills, String introduce) {
+        this.position = position;
+        this.skills = skills;
+        this.introduce = introduce;
+    }
+
+    @Override
+    public ResumeUpdateModel toModel() {
+        ResumeInfo resumeInfo = new ResumeInfo(position, skills, introduce);
+
+        return new ResumeBasicInfoUpdateModel(resumeInfo);
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/business/resume/service/v2/ResumeMemoUpdate.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/service/v2/ResumeMemoUpdate.java
@@ -1,0 +1,19 @@
+package org.devcourse.resumeme.business.resume.service.v2;
+
+import org.devcourse.resumeme.business.resume.domain.model.ResumeMemoUpdateModel;
+import org.devcourse.resumeme.business.resume.domain.model.ResumeUpdateModel;
+
+public class ResumeMemoUpdate implements ResumeUpdateVo {
+
+    private final String memo;
+
+    public ResumeMemoUpdate(String memo) {
+        this.memo = memo;
+    }
+
+    @Override
+    public ResumeUpdateModel toModel() {
+        return new ResumeMemoUpdateModel(memo);
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/business/resume/service/v2/ResumeTitleUpdate.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/service/v2/ResumeTitleUpdate.java
@@ -1,0 +1,19 @@
+package org.devcourse.resumeme.business.resume.service.v2;
+
+import org.devcourse.resumeme.business.resume.domain.model.ResumeTitleUpdateModel;
+import org.devcourse.resumeme.business.resume.domain.model.ResumeUpdateModel;
+
+public class ResumeTitleUpdate implements ResumeUpdateVo {
+
+    private final String title;
+
+    public ResumeTitleUpdate(String title) {
+        this.title = title;
+    }
+
+    @Override
+    public ResumeUpdateModel toModel() {
+        return new ResumeTitleUpdateModel(title);
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/business/resume/service/v2/ResumeUpdateVo.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/service/v2/ResumeUpdateVo.java
@@ -1,0 +1,9 @@
+package org.devcourse.resumeme.business.resume.service.v2;
+
+import org.devcourse.resumeme.business.resume.domain.model.ResumeUpdateModel;
+
+public interface ResumeUpdateVo {
+
+    ResumeUpdateModel toModel();
+
+}

--- a/src/test/java/org/devcourse/resumeme/business/resume/controller/ResumeControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/business/resume/controller/ResumeControllerTest.java
@@ -254,6 +254,8 @@ class ResumeControllerTest extends ControllerUnitTest {
         setModifiedAt(resume2, LocalDateTime.now());
         setPosition(resume1, "FRONT");
         setPosition(resume2, "BACK");
+        setMemo(resume1, "memo");
+        setMemo(resume2, "memo");
 
         given(resumeService.getAllByMenteeId(mentee.getId())).willReturn(List.of(resume1, resume2));
 
@@ -268,7 +270,8 @@ class ResumeControllerTest extends ControllerUnitTest {
                                         fieldWithPath("[].id").type(NUMBER).description("이력서 id"),
                                         fieldWithPath("[].title").type(STRING).description("이력서 제목"),
                                         fieldWithPath("[].modifiedAt").type(STRING).description("수정 일자"),
-                                        fieldWithPath("[].position").type(STRING).description("직무")
+                                        fieldWithPath("[].position").type(STRING).description("직무"),
+                                        fieldWithPath("[].memo").type(STRING).description("메모")
                                 )
                         )
                 );
@@ -362,32 +365,6 @@ class ResumeControllerTest extends ControllerUnitTest {
                                        parameterWithName("resumeId").description("이력서 아이디")
                                )
                        )
-                );
-    }
-
-    @Test
-    void 이력서_메모_조회에_성공한다() throws Exception {
-        // given
-        Long resumeId = 1L;
-        setMemo(resume, "간단한 메모입니다");
-        given(resumeService.getOne(resumeId)).willReturn(resume);
-
-        // when
-        ResultActions result = mvc.perform(get("/api/v1/resumes/{resumeId}/memo", resumeId));
-
-        // then
-        result.andExpect(status().isOk())
-                .andDo(
-                        document("resume/findMemo",
-                                getDocumentRequest(),
-                                getDocumentResponse(),
-                                pathParameters(
-                                        parameterWithName("resumeId").description("이력서 아이디")
-                                ),
-                                responseFields(
-                                        fieldWithPath("memo").type(STRING).description("이력서 메모")
-                                )
-                        )
                 );
     }
 

--- a/src/test/java/org/devcourse/resumeme/business/resume/controller/ResumeControllerV2Test.java
+++ b/src/test/java/org/devcourse/resumeme/business/resume/controller/ResumeControllerV2Test.java
@@ -1,0 +1,132 @@
+package org.devcourse.resumeme.business.resume.controller;
+
+import org.devcourse.resumeme.business.resume.controller.dto.v2.ResumeUpdateRequest;
+import org.devcourse.resumeme.common.ControllerUnitTest;
+import org.devcourse.resumeme.common.support.WithMockCustomUser;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+
+import static org.devcourse.resumeme.common.util.ApiDocumentUtils.getDocumentRequest;
+import static org.devcourse.resumeme.common.util.ApiDocumentUtils.getDocumentResponse;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ResumeControllerV2Test extends ControllerUnitTest {
+
+    @Test
+    void 이력서_제목_수정에_성공한다() throws Exception {
+        // given
+        ResumeUpdateRequest request = new ResumeUpdateRequest(null, null, null, null, "title");
+
+        // when
+        ResultActions result = mvc.perform(patch("/api/v2/resumes/{resumeId}", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(request)));
+
+
+        result
+                .andExpect(status().isOk())
+                .andDo(
+                        document("resume/v2/updateTitle",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                pathParameters(
+                                        parameterWithName("resumeId").description("조회 이력서 id")
+                                ),
+                                nullableHttpRequestSnippet(),
+                                requestFields(
+                                        fieldWithPath("title").type(STRING).description("이력서 제목"),
+                                        fieldWithPath("memo").type(STRING).description("이력서 제목").ignored(),
+                                        fieldWithPath("introduce").type(STRING).description("이력서 제목").ignored(),
+                                        fieldWithPath("skills").type(ARRAY).description("이력서 제목").ignored(),
+                                        fieldWithPath("position").type(STRING).description("이력서 제목").ignored()
+                                ),
+                                responseFields(
+                                        fieldWithPath("id").description("업데이트된 이력서 아이디")
+                                )
+                        )
+                );
+    }
+
+    @Test
+    void 이력서_메모_수정에_성공한다() throws Exception {
+        // given
+        ResumeUpdateRequest request = new ResumeUpdateRequest(null, null, null, "memo", null);
+
+        // when
+        ResultActions result = mvc.perform(patch("/api/v2/resumes/{resumeId}", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(request)));
+
+
+        result
+                .andExpect(status().isOk())
+                .andDo(
+                        document("resume/v2/updateMemo",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                pathParameters(
+                                        parameterWithName("resumeId").description("조회 이력서 id")
+                                ),
+                                nullableHttpRequestSnippet(),
+                                requestFields(
+                                        fieldWithPath("title").type(STRING).description("이력서 제목").ignored(),
+                                        fieldWithPath("memo").type(STRING).description("이력서 제목"),
+                                        fieldWithPath("introduce").type(STRING).description("이력서 제목").ignored(),
+                                        fieldWithPath("skills").type(ARRAY).description("이력서 제목").ignored(),
+                                        fieldWithPath("position").type(STRING).description("이력서 제목").ignored()
+                                ),
+                                responseFields(
+                                        fieldWithPath("id").description("업데이트된 이력서 아이디")
+                                )
+                        )
+                );
+    }
+
+    @Test
+    void 이력서_기본정조_수정에_성공한다() throws Exception {
+        // given
+        ResumeUpdateRequest request = new ResumeUpdateRequest("position", List.of("java", "spring boot"), "소개글", null, null);
+
+        // when
+        ResultActions result = mvc.perform(patch("/api/v2/resumes/{resumeId}", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(request)));
+
+
+        result
+                .andExpect(status().isOk())
+                .andDo(
+                        document("resume/v2/updateBasicInfo",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                pathParameters(
+                                        parameterWithName("resumeId").description("조회 이력서 id")
+                                ),
+                                nullableHttpRequestSnippet(),
+                                requestFields(
+                                        fieldWithPath("title").type(STRING).description("이력서 제목").ignored(),
+                                        fieldWithPath("memo").type(STRING).description("이력서 제목").ignored(),
+                                        fieldWithPath("introduce").type(STRING).description("이력서 제목"),
+                                        fieldWithPath("skills").type(ARRAY).description("이력서 제목"),
+                                        fieldWithPath("position").type(STRING).description("이력서 제목")
+                                ),
+                                responseFields(
+                                        fieldWithPath("id").description("업데이트된 이력서 아이디")
+                                )
+                        )
+                );
+    }
+
+}

--- a/src/test/java/org/devcourse/resumeme/common/ControllerUnitTest.java
+++ b/src/test/java/org/devcourse/resumeme/common/ControllerUnitTest.java
@@ -14,6 +14,7 @@ import org.devcourse.resumeme.business.result.controller.ResultNoticeController;
 import org.devcourse.resumeme.business.result.service.ResultService;
 import org.devcourse.resumeme.business.resume.controller.ComponentController;
 import org.devcourse.resumeme.business.resume.controller.ResumeController;
+import org.devcourse.resumeme.business.resume.controller.ResumeControllerV2;
 import org.devcourse.resumeme.business.resume.service.ComponentService;
 import org.devcourse.resumeme.business.resume.service.ResumeService;
 import org.devcourse.resumeme.business.user.controller.UserController;
@@ -25,6 +26,7 @@ import org.devcourse.resumeme.business.user.service.mentee.MenteeService;
 import org.devcourse.resumeme.business.user.service.mentor.MentorService;
 import org.devcourse.resumeme.business.userevent.controller.UserEventController;
 import org.devcourse.resumeme.common.controller.EnumController;
+import org.devcourse.resumeme.common.support.NullableHttpRequestSnippet;
 import org.devcourse.resumeme.global.auth.filter.FilterTestController;
 import org.devcourse.resumeme.global.auth.filter.JwtAuthorizationFilter;
 import org.devcourse.resumeme.global.auth.filter.OAuthTokenResponseFilter;
@@ -159,6 +161,10 @@ public abstract class ControllerUnitTest {
 
     protected static ExceptionResponseFieldsSnippet exceptionResponse(List<String> exceptions) {
         return new ExceptionResponseFieldsSnippet("exception-response", Map.of("exceptions", String.join(", ", exceptions)));
+    }
+
+    protected static NullableHttpRequestSnippet nullableHttpRequestSnippet() {
+        return new NullableHttpRequestSnippet();
     }
 
     protected static class ExceptionResponseFieldsSnippet extends TemplatedSnippet {

--- a/src/test/java/org/devcourse/resumeme/common/ControllerUnitTest.java
+++ b/src/test/java/org/devcourse/resumeme/common/ControllerUnitTest.java
@@ -75,6 +75,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
         ComponentController.class,
         FilterTestController.class,
         UserEventController.class,
+        ResumeControllerV2.class,
         EventControllerV2.class
 })
 @AutoConfigureRestDocs

--- a/src/test/java/org/devcourse/resumeme/common/support/NullableHttpRequestSnippet.java
+++ b/src/test/java/org/devcourse/resumeme/common/support/NullableHttpRequestSnippet.java
@@ -1,0 +1,49 @@
+package org.devcourse.resumeme.common.support;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.restdocs.http.HttpRequestSnippet;
+import org.springframework.restdocs.operation.Operation;
+import org.springframework.restdocs.operation.OperationRequest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class NullableHttpRequestSnippet extends HttpRequestSnippet {
+
+    public NullableHttpRequestSnippet() {
+        super();
+    }
+
+    @Override
+    protected Map<String, Object> createModel(Operation operation) {
+        Map<String, Object> model = super.createModel(operation);
+        try {
+            model.put("requestBody", getRequestBody(operation.getRequest()));
+
+            return model;
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String getRequestBody(OperationRequest operation) throws JsonProcessingException {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            String content = operation.getContentAsString();
+            Map<String, Object> contents = mapper.readValue(content, Map.class);
+
+            Map<String, Object> result = new HashMap<>();
+            for (Map.Entry<String, Object> entry : contents.entrySet()) {
+                if (entry.getValue() != null) {
+                    result.put(entry.getKey(), entry.getValue());
+                }
+            }
+
+            return "\n%s".formatted(mapper.writeValueAsString(result));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
이력서 업데이트 api 통합
이력서 메모 조회 개별 -> 이력서 리스트 조회 반환값에 통합

## CC. 리뷰어
일단 v2로 지정해뒀습니다

이력서 메모는 리스트 조회시만 사용한다해서 통합했습니다

## 테스트 설명


## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
