### PR TITLE
fix: resumeData column 타입 명시

### DIFF
--- a/src/main/java/org/devcourse/resumeme/business/resume/entity/Snapshot.java
+++ b/src/main/java/org/devcourse/resumeme/business/resume/entity/Snapshot.java
@@ -20,6 +20,7 @@ public class Snapshot {
 
     @Lob
     @Getter
+    @Column(columnDefinition = "LONGTEXT")
     private String resumeData;
 
     private Long resumeId;


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
resumeData column 타입 명시

## CC. 리뷰어
기존에는 계속 `@Lob`이 tinyText로 지정이 되어서 해당 타입 Longtext로 직접 명시했습니다

## 테스트 설명


## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
