### PR TITLE
feat: 관심멘토 설정 기능

### DIFF
--- a/src/docs/asciidoc/mentee.adoc
+++ b/src/docs/asciidoc/mentee.adoc
@@ -291,3 +291,33 @@ include::{snippets}/result/create/request-fields.adoc[]
 *Response*
 include::{snippets}/result/create/http-response.adoc[]
 include::{snippets}/result/create/response-fields.adoc[]
+
+== [관심 멘토 팔로우]
+=== 멘토 팔로우하기
+include::{snippets}/follows/create/exception-response.adoc[]
+
+*Request*
+include::{snippets}/follows/create/http-request.adoc[]
+include::{snippets}/follows/create/request-fields.adoc[]
+
+*Response*
+include::{snippets}/follows/create/http-response.adoc[]
+include::{snippets}/follows/create/response-fields.adoc[]
+
+=== 팔로우 중인 멘토 리스트 조회하기
+
+*Request*
+include::{snippets}/follows/getAll/http-request.adoc[]
+
+*Response*
+include::{snippets}/follows/getAll/http-response.adoc[]
+include::{snippets}/follows/getAll/response-fields.adoc[]
+
+=== 멘토 팔로우 취소하기
+
+*Request*
+include::{snippets}/follows/delete/http-request.adoc[]
+include::{snippets}/follows/delete/path-parameters.adoc[]
+
+*Response*
+include::{snippets}/follows/delete/http-response.adoc[]

--- a/src/main/java/org/devcourse/resumeme/business/user/controller/FollowController.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/controller/FollowController.java
@@ -5,6 +5,7 @@ import org.devcourse.resumeme.business.user.controller.dto.FollowRequest;
 import org.devcourse.resumeme.business.user.controller.dto.FollowResponse;
 import org.devcourse.resumeme.business.user.domain.mentee.Follow;
 import org.devcourse.resumeme.business.user.service.mentee.FollowService;
+import org.devcourse.resumeme.business.user.service.mentor.MentorService;
 import org.devcourse.resumeme.common.response.IdResponse;
 import org.devcourse.resumeme.global.auth.model.jwt.JwtUser;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -25,11 +26,13 @@ public class FollowController {
 
     private final FollowService followService;
 
+    private final MentorService mentorService;
+
     @GetMapping
     public List<FollowResponse> getFollowList(@AuthenticationPrincipal JwtUser user) {
         return followService.getFollowings(user.id())
                 .stream()
-                .map(FollowResponse::new)
+                .map(follow -> new FollowResponse(follow, mentorService.getOne(follow.getMentorId())))
                 .toList();
     }
 

--- a/src/main/java/org/devcourse/resumeme/business/user/controller/FollowController.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/controller/FollowController.java
@@ -1,0 +1,49 @@
+package org.devcourse.resumeme.business.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.devcourse.resumeme.business.user.controller.dto.FollowRequest;
+import org.devcourse.resumeme.business.user.controller.dto.FollowResponse;
+import org.devcourse.resumeme.business.user.domain.mentee.Follow;
+import org.devcourse.resumeme.business.user.service.mentee.FollowService;
+import org.devcourse.resumeme.common.response.IdResponse;
+import org.devcourse.resumeme.global.auth.model.jwt.JwtUser;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/follows")
+@RequiredArgsConstructor
+public class FollowController {
+
+    private final FollowService followService;
+
+    @GetMapping
+    public List<FollowResponse> getFollowList(@AuthenticationPrincipal JwtUser user) {
+        return followService.getFollowings(user.id())
+                .stream()
+                .map(FollowResponse::new)
+                .toList();
+    }
+
+    @PostMapping
+    public IdResponse doFollow(@RequestBody FollowRequest request, @AuthenticationPrincipal JwtUser user) {
+        Follow follow = new Follow(user.id(), request.mentorId());
+        Long followId = followService.create(follow);
+
+        return new IdResponse(followId);
+    }
+
+    @DeleteMapping("/{followId}")
+    public void unFollow(@PathVariable Long followId) {
+        followService.unfollow(followId);
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/business/user/controller/FollowController.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/controller/FollowController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.devcourse.resumeme.business.user.controller.dto.FollowRequest;
 import org.devcourse.resumeme.business.user.controller.dto.FollowResponse;
 import org.devcourse.resumeme.business.user.domain.mentee.Follow;
+import org.devcourse.resumeme.business.user.domain.mentor.Mentor;
 import org.devcourse.resumeme.business.user.service.mentee.FollowService;
 import org.devcourse.resumeme.business.user.service.mentor.MentorService;
 import org.devcourse.resumeme.common.response.IdResponse;
@@ -30,9 +31,12 @@ public class FollowController {
 
     @GetMapping
     public List<FollowResponse> getFollowList(@AuthenticationPrincipal JwtUser user) {
-        return followService.getFollowings(user.id())
-                .stream()
-                .map(follow -> new FollowResponse(follow, mentorService.getOne(follow.getMentorId())))
+        List<Follow> followings = followService.getFollowings(user.id());
+        List<Long> mentorIds = followings.stream().map(Follow::getMentorId).toList();
+        List<Mentor> followingMentors = mentorService.getAllByIds(mentorIds);
+
+        return followings.stream()
+                .map(follow -> new FollowResponse(follow, followingMentors.stream().filter(mentor -> mentor.getId().equals(follow.getMentorId())).findFirst().get()))
                 .toList();
     }
 

--- a/src/main/java/org/devcourse/resumeme/business/user/controller/dto/FollowRequest.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/controller/dto/FollowRequest.java
@@ -1,0 +1,5 @@
+package org.devcourse.resumeme.business.user.controller.dto;
+
+public record FollowRequest(Long mentorId) {
+
+}

--- a/src/main/java/org/devcourse/resumeme/business/user/controller/dto/FollowResponse.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/controller/dto/FollowResponse.java
@@ -1,11 +1,13 @@
 package org.devcourse.resumeme.business.user.controller.dto;
 
+import org.devcourse.resumeme.business.user.controller.mentor.dto.MentorInfoResponse;
 import org.devcourse.resumeme.business.user.domain.mentee.Follow;
+import org.devcourse.resumeme.business.user.domain.mentor.Mentor;
 
-public record FollowResponse(Long followId, Long mentorId) {
+public record FollowResponse(Long followId, MentorInfoResponse mentorInfo) {
 
-    public FollowResponse(Follow follow) {
-        this(follow.getId(), follow.getMentorId());
+    public FollowResponse(Follow follow, Mentor mentor) {
+        this(follow.getId(), new MentorInfoResponse(mentor));
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/business/user/controller/dto/FollowResponse.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/controller/dto/FollowResponse.java
@@ -1,0 +1,11 @@
+package org.devcourse.resumeme.business.user.controller.dto;
+
+import org.devcourse.resumeme.business.user.domain.mentee.Follow;
+
+public record FollowResponse(Long followId, Long mentorId) {
+
+    public FollowResponse(Follow follow) {
+        this(follow.getId(), follow.getMentorId());
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/business/user/controller/mentor/dto/MentorInfoResponse.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/controller/mentor/dto/MentorInfoResponse.java
@@ -5,10 +5,10 @@ import org.devcourse.resumeme.business.user.domain.mentor.Mentor;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public record MentorInfoResponse(String imageUrl, String nickname, Set<String> experiencedPositions, String careerContent, int careerYear, String introduce) {
+public record MentorInfoResponse(Long id, String imageUrl, String nickname, Set<String> experiencedPositions, String careerContent, int careerYear, String introduce) {
 
     public MentorInfoResponse(Mentor mentor) {
-        this(mentor.getImageUrl(), mentor.getRequiredInfo().getNickname(), getExperiencedPositions(mentor), mentor.getCareerContent(), mentor.getCareerYear(), mentor.getIntroduce());
+        this(mentor.getId(), mentor.getImageUrl(), mentor.getRequiredInfo().getNickname(), getExperiencedPositions(mentor), mentor.getCareerContent(), mentor.getCareerYear(), mentor.getIntroduce());
     }
 
     private static Set<String> getExperiencedPositions(Mentor mentor) {

--- a/src/main/java/org/devcourse/resumeme/business/user/domain/mentee/Follow.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/domain/mentee/Follow.java
@@ -1,0 +1,32 @@
+package org.devcourse.resumeme.business.user.domain.mentee;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@EqualsAndHashCode(exclude = "id")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Follow {
+
+    @Id
+    @GeneratedValue
+    @Column(name ="follow_id")
+    private Long id;
+
+    private Long menteeId;
+
+    private Long mentorId;
+
+    public Follow(Long menteeId, Long mentorId) {
+        this.menteeId = menteeId;
+        this.mentorId = mentorId;
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/business/user/domain/mentee/Mentee.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/domain/mentee/Mentee.java
@@ -16,11 +16,9 @@ import lombok.NoArgsConstructor;
 import org.devcourse.resumeme.business.user.controller.mentee.dto.MenteeInfoUpdateRequest;
 import org.devcourse.resumeme.business.user.domain.Provider;
 import org.devcourse.resumeme.business.user.domain.Role;
-import org.devcourse.resumeme.business.user.domain.mentor.Mentor;
 import org.devcourse.resumeme.common.domain.BaseEntity;
 import org.devcourse.resumeme.common.domain.Field;
 import org.devcourse.resumeme.common.domain.Position;
-import org.devcourse.resumeme.global.exception.CustomException;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -28,10 +26,7 @@ import java.util.stream.Collectors;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static org.devcourse.resumeme.common.util.Validator.check;
-import static org.devcourse.resumeme.global.exception.ExceptionCode.ALREADY_FOLLOWING;
-import static org.devcourse.resumeme.global.exception.ExceptionCode.FOLLOW_ALREADY_FULL;
 import static org.devcourse.resumeme.global.exception.ExceptionCode.INVALID_EMAIL;
-import static org.devcourse.resumeme.global.exception.ExceptionCode.NOT_FOLLOWING_NOW;
 import static org.devcourse.resumeme.global.exception.ExceptionCode.NO_EMPTY_VALUE;
 import static org.devcourse.resumeme.global.exception.ExceptionCode.ROLE_NOT_ALLOWED;
 import static org.devcourse.resumeme.global.exception.ExceptionCode.TEXT_OVER_LENGTH;
@@ -41,8 +36,6 @@ import static org.devcourse.resumeme.global.exception.ExceptionCode.TEXT_OVER_LE
 public class Mentee extends BaseEntity {
 
     static final String EMAIL_REGEX = "^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$";
-
-    static final int MAX_FOLLOW_SIZE = 3;
 
     @Id
     @Getter
@@ -78,9 +71,6 @@ public class Mentee extends BaseEntity {
 
     @Getter
     private String introduce;
-
-    @OneToMany(fetch = LAZY, mappedBy = "mentee", cascade = {CascadeType.PERSIST,CascadeType.REMOVE}, orphanRemoval = true)
-    private Set<Follow> followings = new HashSet<>();
 
     @Builder
     public Mentee(Long id,String email, Provider provider, String imageUrl, RequiredInfo requiredInfo, String refreshToken, Set<String> interestedPositions, Set<String> interestedFields, String introduce) {
@@ -134,21 +124,6 @@ public class Mentee extends BaseEntity {
     private void updateIntroduce(String introduce) {
         check(introduce != null && introduce.length() > 100, TEXT_OVER_LENGTH);
         this.introduce = introduce;
-    }
-
-    private void follow(Mentor mentor) {
-        if (followings.size() > MAX_FOLLOW_SIZE - 1) {
-            throw new CustomException(FOLLOW_ALREADY_FULL);
-        }
-        if (!followings.add(new Follow(this, mentor))) {
-            throw new CustomException(ALREADY_FOLLOWING);
-        }
-    }
-
-    private void unfollow(Mentor mentor) {
-        if (!followings.remove(new Follow(this, mentor))) {
-            throw new CustomException(NOT_FOLLOWING_NOW);
-        }
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/business/user/domain/mentee/Mentee.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/domain/mentee/Mentee.java
@@ -13,12 +13,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.devcourse.resumeme.common.domain.BaseEntity;
-import org.devcourse.resumeme.common.domain.Field;
-import org.devcourse.resumeme.common.domain.Position;
 import org.devcourse.resumeme.business.user.controller.mentee.dto.MenteeInfoUpdateRequest;
 import org.devcourse.resumeme.business.user.domain.Provider;
 import org.devcourse.resumeme.business.user.domain.Role;
+import org.devcourse.resumeme.business.user.domain.mentor.Mentor;
+import org.devcourse.resumeme.common.domain.BaseEntity;
+import org.devcourse.resumeme.common.domain.Field;
+import org.devcourse.resumeme.common.domain.Position;
+import org.devcourse.resumeme.global.exception.CustomException;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -26,7 +28,10 @@ import java.util.stream.Collectors;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static org.devcourse.resumeme.common.util.Validator.check;
+import static org.devcourse.resumeme.global.exception.ExceptionCode.ALREADY_FOLLOWING;
+import static org.devcourse.resumeme.global.exception.ExceptionCode.FOLLOW_ALREADY_FULL;
 import static org.devcourse.resumeme.global.exception.ExceptionCode.INVALID_EMAIL;
+import static org.devcourse.resumeme.global.exception.ExceptionCode.NOT_FOLLOWING_NOW;
 import static org.devcourse.resumeme.global.exception.ExceptionCode.NO_EMPTY_VALUE;
 import static org.devcourse.resumeme.global.exception.ExceptionCode.ROLE_NOT_ALLOWED;
 import static org.devcourse.resumeme.global.exception.ExceptionCode.TEXT_OVER_LENGTH;
@@ -36,6 +41,8 @@ import static org.devcourse.resumeme.global.exception.ExceptionCode.TEXT_OVER_LE
 public class Mentee extends BaseEntity {
 
     static final String EMAIL_REGEX = "^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$";
+
+    static final int MAX_FOLLOW_SIZE = 3;
 
     @Id
     @Getter
@@ -71,6 +78,9 @@ public class Mentee extends BaseEntity {
 
     @Getter
     private String introduce;
+
+    @OneToMany(fetch = LAZY, mappedBy = "mentee", cascade = {CascadeType.PERSIST,CascadeType.REMOVE}, orphanRemoval = true)
+    private Set<Follow> followings = new HashSet<>();
 
     @Builder
     public Mentee(Long id,String email, Provider provider, String imageUrl, RequiredInfo requiredInfo, String refreshToken, Set<String> interestedPositions, Set<String> interestedFields, String introduce) {
@@ -124,6 +134,21 @@ public class Mentee extends BaseEntity {
     private void updateIntroduce(String introduce) {
         check(introduce != null && introduce.length() > 100, TEXT_OVER_LENGTH);
         this.introduce = introduce;
+    }
+
+    private void follow(Mentor mentor) {
+        if (followings.size() > MAX_FOLLOW_SIZE - 1) {
+            throw new CustomException(FOLLOW_ALREADY_FULL);
+        }
+        if (!followings.add(new Follow(this, mentor))) {
+            throw new CustomException(ALREADY_FOLLOWING);
+        }
+    }
+
+    private void unfollow(Mentor mentor) {
+        if (!followings.remove(new Follow(this, mentor))) {
+            throw new CustomException(NOT_FOLLOWING_NOW);
+        }
     }
 
 }

--- a/src/main/java/org/devcourse/resumeme/business/user/repository/FollowRepository.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/repository/FollowRepository.java
@@ -1,0 +1,12 @@
+package org.devcourse.resumeme.business.user.repository;
+
+import org.devcourse.resumeme.business.user.domain.mentee.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    List<Follow> findAllByMenteeId(Long menteeId);
+
+}

--- a/src/main/java/org/devcourse/resumeme/business/user/service/mentee/FollowService.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/service/mentee/FollowService.java
@@ -1,0 +1,50 @@
+package org.devcourse.resumeme.business.user.service.mentee;
+
+import lombok.RequiredArgsConstructor;
+import org.devcourse.resumeme.business.user.domain.mentee.Follow;
+import org.devcourse.resumeme.business.user.repository.FollowRepository;
+import org.devcourse.resumeme.global.exception.CustomException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.devcourse.resumeme.global.exception.ExceptionCode.ALREADY_FOLLOWING;
+import static org.devcourse.resumeme.global.exception.ExceptionCode.EXCEEDED_FOLLOW_MAX;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FollowService {
+
+    private final int MAX_FOLLOW_SIZE = 3;
+
+    private final FollowRepository followRepository;
+
+    public Long create(Follow follow) {
+        List<Follow> followList = getFollowings(follow.getMenteeId());
+
+        if (followList.size() > MAX_FOLLOW_SIZE - 1) {
+            throw new CustomException(EXCEEDED_FOLLOW_MAX);
+        }
+        if (isFollowing(followList, follow.getMentorId())) {
+            throw new CustomException(ALREADY_FOLLOWING);
+        }
+
+        return followRepository.save(follow).getId();
+    }
+
+    @Transactional(readOnly = true)
+    public List<Follow> getFollowings(Long menteeId) {
+        return followRepository.findAllByMenteeId(menteeId);
+    }
+
+    public void unfollow(Long followId) {
+        followRepository.deleteById(followId);
+    }
+
+    private boolean isFollowing(List<Follow> followList, Long mentorId) {
+        return followList.stream().anyMatch(follow -> follow.getMentorId().equals(mentorId));
+    }
+
+}

--- a/src/main/java/org/devcourse/resumeme/business/user/service/mentor/MentorService.java
+++ b/src/main/java/org/devcourse/resumeme/business/user/service/mentor/MentorService.java
@@ -10,6 +10,8 @@ import org.devcourse.resumeme.business.user.repository.mentor.MentorRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static org.devcourse.resumeme.global.exception.ExceptionCode.MENTOR_NOT_FOUND;
 
 @Service
@@ -60,4 +62,7 @@ public class MentorService {
         updateRefreshToken(id, null);
     }
 
+    public List<Mentor> getAllByIds(List<Long> mentorIds) {
+        return mentorRepository.findAllById(mentorIds);
+    }
 }

--- a/src/main/java/org/devcourse/resumeme/global/exception/ExceptionCode.java
+++ b/src/main/java/org/devcourse/resumeme/global/exception/ExceptionCode.java
@@ -38,7 +38,11 @@ public enum ExceptionCode implements DocsEnumType {
     INVALID_EMAIL("이메일이 유효하지 않습니다"),
     NOT_FOUND_DATA("정보를 찾을 수 없습니다"),
     COMMENT_NOT_FOUND("작성된 피드백이 없습니다"),
-    NOT_FOUND_SNAPSHOT("저장된 스냅샷이 없습니다")
+    NOT_FOUND_SNAPSHOT("저장된 스냅샷이 없습니다"),
+    INVALID_EMAIL("이메일이 유효하지 않습니다"),
+    FOLLOW_ALREADY_FULL("팔로우 가능한 멘토 인원이 초과되었습니다"),
+    ALREADY_FOLLOWING("이미 팔로우 중인 멘토입니다"),
+    NOT_FOLLOWING_NOW("현재 팔로우 하고있지 않은 멘토입니다")
     ;
 
     private final String message;

--- a/src/main/java/org/devcourse/resumeme/global/exception/ExceptionCode.java
+++ b/src/main/java/org/devcourse/resumeme/global/exception/ExceptionCode.java
@@ -39,8 +39,7 @@ public enum ExceptionCode implements DocsEnumType {
     NOT_FOUND_DATA("정보를 찾을 수 없습니다"),
     COMMENT_NOT_FOUND("작성된 피드백이 없습니다"),
     NOT_FOUND_SNAPSHOT("저장된 스냅샷이 없습니다"),
-    INVALID_EMAIL("이메일이 유효하지 않습니다"),
-    FOLLOW_ALREADY_FULL("팔로우 가능한 멘토 인원이 초과되었습니다"),
+    EXCEEDED_FOLLOW_MAX("팔로우 가능한 멘토 인원이 초과되었습니다"),
     ALREADY_FOLLOWING("이미 팔로우 중인 멘토입니다"),
     NOT_FOLLOWING_NOW("현재 팔로우 하고있지 않은 멘토입니다")
     ;

--- a/src/main/resources/application-endpoint.yml
+++ b/src/main/resources/application-endpoint.yml
@@ -8,6 +8,7 @@ endpoint:
         get: /api/v1/mentees/*, /api/v1/user, /api/v1/resumes, /api/v1/results, /api/v1/mentees/*/events, /api/v1/snapshot
         post: /api/v1/resumes, /api/v1/results, /api/v1/pdf/resumes/*, /api/v1/resumes/*/**, /api/v1/appliments/events/*
         patch: /api/v1/mentees/*, /api/v1/resumes/*, /api/v1/resumes/*/**
+        delete: /api/v1/follows/*
       role: mentee
     - matcher:
         get: /api/v1/mentors/*, /api/v1/mentees/*, /api/v1/user, /api/v1/resumes/**, /api/v1/results, /api/v1/mentors/*/events

--- a/src/main/resources/application-endpoint.yml
+++ b/src/main/resources/application-endpoint.yml
@@ -5,8 +5,8 @@ endpoint:
         post: /api/v1/mentees, /api/v1/mentors
       role: all
     - matcher:
-        get: /api/v1/mentees/*, /api/v1/user, /api/v1/resumes, /api/v1/results, /api/v1/mentees/*/events, /api/v1/snapshot
-        post: /api/v1/resumes, /api/v1/results, /api/v1/pdf/resumes/*, /api/v1/resumes/*/**, /api/v1/appliments/events/*
+        get: /api/v1/mentees/*, /api/v1/user, /api/v1/resumes, /api/v1/results, /api/v1/mentees/*/events, /api/v1/snapshot, /api/v1/follows
+        post: /api/v1/resumes, /api/v1/results, /api/v1/pdf/resumes/*, /api/v1/resumes/*/**, /api/v1/appliments/events/*, /api/v1/follows
         patch: /api/v1/mentees/*, /api/v1/resumes/*, /api/v1/resumes/*/**
         delete: /api/v1/follows/*
       role: mentee

--- a/src/test/java/org/devcourse/resumeme/business/user/controller/FollowControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/business/user/controller/FollowControllerTest.java
@@ -92,7 +92,7 @@ class FollowControllerTest extends ControllerUnitTest {
                 .build();
 
         Mentor mentorThree =  Mentor.builder()
-                .id(2L)
+                .id(3L)
                 .imageUrl("profile.png")
                 .provider(Provider.valueOf("KAKAO"))
                 .email("progs3rs33@gmail.com")
@@ -110,8 +110,7 @@ class FollowControllerTest extends ControllerUnitTest {
         setId(followMentorThree, 2L);
 
         given(followService.getFollowings(any(Long.class))).willReturn(List.of(followMentorOne, followMentorThree));
-        given(mentorService.getOne(1L)).willReturn(mentorOne);
-        given(mentorService.getOne(3L)).willReturn(mentorThree);
+        given(mentorService.getAllByIds(any())).willReturn(List.of(mentorOne, mentorThree));
 
         // when
         ResultActions result = mvc.perform(get("/api/v1/follows"));

--- a/src/test/java/org/devcourse/resumeme/business/user/controller/FollowControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/business/user/controller/FollowControllerTest.java
@@ -1,0 +1,128 @@
+package org.devcourse.resumeme.business.user.controller;
+
+import org.devcourse.resumeme.business.user.controller.dto.FollowRequest;
+import org.devcourse.resumeme.business.user.domain.mentee.Follow;
+import org.devcourse.resumeme.common.ControllerUnitTest;
+import org.devcourse.resumeme.common.support.WithMockCustomUser;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+
+import static org.devcourse.resumeme.common.util.ApiDocumentUtils.getDocumentRequest;
+import static org.devcourse.resumeme.global.exception.ExceptionCode.ALREADY_FOLLOWING;
+import static org.devcourse.resumeme.global.exception.ExceptionCode.EXCEEDED_FOLLOW_MAX;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class FollowControllerTest extends ControllerUnitTest {
+
+    @Test
+    @WithMockCustomUser
+    void 멘티는_첨삭_이벤트_오픈_알림을_받고싶은_멘토를_팔로우_할_수_있다() throws Exception {
+        // given
+        FollowRequest request = new FollowRequest(1L);
+        given(followService.create(any(Follow.class))).willReturn(1L);
+
+        // when
+        ResultActions result = mvc.perform(post("/api/v1/follows")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(request)));
+
+        // then
+        result
+                .andExpect(status().isOk())
+                .andDo(
+                        document("follows/create",
+                                getDocumentRequest(),
+                                exceptionResponse(
+                                        List.of(EXCEEDED_FOLLOW_MAX.name(), ALREADY_FOLLOWING.name())
+                                ),
+                                requestFields(
+                                        fieldWithPath("mentorId").type(NUMBER).description("멘토 아이디")
+                                ),
+                                responseFields(
+                                        fieldWithPath("id").type(NUMBER).description("생성된 팔로우 아이디")
+                                )
+                        )
+                );
+    }
+
+    @Test
+    @WithMockCustomUser
+    void 멘티의_팔로잉_하는_멘토_리스트를_조회할_수_있다() throws Exception {
+        // given
+        Follow followMentorOne = new Follow(1L, 1L);
+        Follow followMentorThree = new Follow(1L, 3L);
+        Follow followMentorFour = new Follow(1L, 4L);
+        Follow followMentorEleven = new Follow(1L, 11L);
+        setId(followMentorOne, 1L);
+        setId(followMentorThree, 2L);
+        setId(followMentorFour, 4L);
+        setId(followMentorEleven, 5L);
+
+        given(followService.getFollowings(any(Long.class))).willReturn(List.of(followMentorOne, followMentorThree, followMentorFour, followMentorEleven));
+
+        // when
+        ResultActions result = mvc.perform(get("/api/v1/follows"));
+
+        // then
+        result
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(
+                        document("follows/getAll",
+                                responseFields(
+//                                        fieldWithPath("[]").type(ARRAY).description("이벤트 아이디"),
+                                        fieldWithPath("[0].followId").type(NUMBER).description("팔로우 아이디"),
+                                        fieldWithPath("[0].mentorId").type(NUMBER).description("팔로우 하는 멘토 아이디"),
+                                        fieldWithPath("[1].followId").type(NUMBER).description("팔로우 아이디"),
+                                        fieldWithPath("[1].mentorId").type(NUMBER).description("팔로우 하는 멘토 아이디"),
+                                        fieldWithPath("[2].followId").type(NUMBER).description("팔로우 아이디"),
+                                        fieldWithPath("[2].mentorId").type(NUMBER).description("팔로우 하는 멘토 아이디"),
+                                        fieldWithPath("[3].followId").type(NUMBER).description("팔로우 아이디"),
+                                        fieldWithPath("[3].mentorId").type(NUMBER).description("팔로우 하는 멘토 아이디")
+
+                                )
+                        )
+                );
+
+    }
+
+    @Test
+    @WithMockCustomUser
+    void 특정_멘토에_대해_팔로우를_취소할_수_있다() throws Exception {
+        // given
+        doNothing().when(followService).unfollow(any(Long.class));
+
+        // when
+        // when
+        ResultActions result = mvc.perform(delete("/api/v1/follows/{followId}", 1L));
+
+        // then
+        result
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(
+                        document("follows/delete",
+                                pathParameters(
+                                        parameterWithName("followId").description("삭제하려는 팔로우 아이디")
+                                )
+                        )
+                );
+    }
+}

--- a/src/test/java/org/devcourse/resumeme/business/user/controller/mentor/MentorControllerTest.java
+++ b/src/test/java/org/devcourse/resumeme/business/user/controller/mentor/MentorControllerTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.INTEGER;
 import static org.assertj.core.api.Assertions.MAP;
+import static org.assertj.core.api.InstanceOfAssertFactories.LONG;
 import static org.devcourse.resumeme.common.util.ApiDocumentUtils.constraints;
 import static org.devcourse.resumeme.common.util.ApiDocumentUtils.getDocumentRequest;
 import static org.devcourse.resumeme.common.util.ApiDocumentUtils.getDocumentResponse;
@@ -213,9 +214,10 @@ class MentorControllerTest extends ControllerUnitTest {
                                         parameterWithName("mentorId").description("멘토 id")
                                 ),
                                 responseFields(
+                                        fieldWithPath("id").type(LONG).description("멘토 id"),
                                         fieldWithPath("imageUrl").type(STRING).description("프로필 이미지"),
                                         fieldWithPath("nickname").type(STRING).description("닉네임"),
-                                        fieldWithPath("experiencedPositions").type(ARRAY).description("활동 직무").description(generateLinkCode(DocumentLinkGenerator.DocUrl.POSITION)).optional(),
+                                        fieldWithPath("experiencedPositions").type(ARRAY).description("활동 직무").description(generateLinkCode(DocumentLinkGenerator.DocUrl.POSITION)),
                                         fieldWithPath("careerContent").type(STRING).description("경력 사항"),
                                         fieldWithPath("careerYear").type(INTEGER).description("경력 연차"),
                                         fieldWithPath("introduce").type(STRING).description("자기소개").optional()

--- a/src/test/java/org/devcourse/resumeme/common/ControllerUnitTest.java
+++ b/src/test/java/org/devcourse/resumeme/common/ControllerUnitTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.devcourse.resumeme.business.comment.controller.CommentController;
 import org.devcourse.resumeme.business.comment.service.CommentService;
 import org.devcourse.resumeme.business.event.controller.EventController;
+import org.devcourse.resumeme.business.event.controller.EventControllerV2;
 import org.devcourse.resumeme.business.event.controller.MenteeToEventController;
 import org.devcourse.resumeme.business.event.service.EventPositionService;
 import org.devcourse.resumeme.business.event.service.EventService;
@@ -19,11 +20,13 @@ import org.devcourse.resumeme.business.resume.controller.SnapshotController;
 import org.devcourse.resumeme.business.resume.service.ComponentService;
 import org.devcourse.resumeme.business.resume.service.ResumeService;
 import org.devcourse.resumeme.business.resume.service.SnapshotService;
+import org.devcourse.resumeme.business.user.controller.FollowController;
 import org.devcourse.resumeme.business.user.controller.UserController;
 import org.devcourse.resumeme.business.user.controller.admin.MentorApplicationController;
 import org.devcourse.resumeme.business.user.controller.mentee.MenteeController;
 import org.devcourse.resumeme.business.user.controller.mentor.MentorController;
 import org.devcourse.resumeme.business.user.service.admin.MentorApplicationService;
+import org.devcourse.resumeme.business.user.service.mentee.FollowService;
 import org.devcourse.resumeme.business.user.service.mentee.MenteeService;
 import org.devcourse.resumeme.business.user.service.mentor.MentorService;
 import org.devcourse.resumeme.business.userevent.controller.UserEventController;
@@ -78,6 +81,9 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
         FilterTestController.class,
         UserEventController.class,
         ResumeControllerV2.class,
+        EventControllerV2.class,
+        SnapshotController.class,
+        FollowController.class,
         MenteeToEventController.class,
         SnapshotController.class
 })
@@ -130,6 +136,9 @@ public abstract class ControllerUnitTest {
 
     @MockBean
     protected SnapshotService snapshotService;
+
+    @MockBean
+    protected FollowService followService;
 
     protected MockMvc mvc;
 

--- a/src/test/java/org/devcourse/resumeme/common/ControllerUnitTest.java
+++ b/src/test/java/org/devcourse/resumeme/common/ControllerUnitTest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.devcourse.resumeme.business.comment.controller.CommentController;
 import org.devcourse.resumeme.business.comment.service.CommentService;
 import org.devcourse.resumeme.business.event.controller.EventController;
-import org.devcourse.resumeme.business.event.controller.EventControllerV2;
 import org.devcourse.resumeme.business.event.controller.MenteeToEventController;
 import org.devcourse.resumeme.business.event.service.EventPositionService;
 import org.devcourse.resumeme.business.event.service.EventService;
@@ -81,7 +80,6 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
         FilterTestController.class,
         UserEventController.class,
         ResumeControllerV2.class,
-        EventControllerV2.class,
         SnapshotController.class,
         FollowController.class,
         MenteeToEventController.class,


### PR DESCRIPTION
##  🖥️  이런 PR 입니다
- 팔로우와 멘토, 멘티 사이 연관관계 삭제 -> id 값으로 대체
- 팔로우 가능한 최대 멘토 수는 3명으로 제한

## CC. 리뷰어
- 이전 PR과 내용은 거의 비슷하고, 연관관계는 끊었습니다.

## 테스트 설명


## 기타
**Prefix**

PR 코멘트를 작성할 때 항상 Prefix를 붙여주세요.

- K1: 꼭 반영해주세요 (Request changes)
- K2: 웬만하면 반영해 주세요 (Comment)
- K3: 그냥 사소한 의견입니다 (Approve)
